### PR TITLE
fix(server): unlinearize when converting from RGB to YUV

### DIFF
--- a/mm-client/src/shaders/frag.glsl
+++ b/mm-client/src/shaders/frag.glsl
@@ -10,6 +10,35 @@ layout(location = 0) in vec2 uv;
 
 layout(location = 0) out vec4 color;
 
+float srgb_unlinear(float s) {
+    return mix(12.92*s, 1.055*pow(s, 1.0/2.4) - 0.055, s >= 0.0031);
+}
+
+// Rec. 2020 uses the same transfer function as Rec. 709, so we don't need to
+// distinguish between them. We currently only support those two color spaces.
+float linearize(float s) {
+    return mix(
+        s / 4.5,
+        pow((s + 0.099) / 1.099, 1.0 / 0.45),
+        s > 0.081);
+}
+
 void main() {
-    color = texture(tex, uv);
+    // When sampling the video texture, vulkan does the matrix multiplication
+    // for us, but doesn't apply any transfer function.
+    vec4 rgb709 = texture(tex, uv);
+    vec4 linear = vec4(
+        linearize(rgb709.r),
+        linearize(rgb709.g),
+        linearize(rgb709.b),
+        rgb709.a
+    );
+
+    // Unlinearize back into sRGB for rendering.
+    color = vec4(
+        srgb_unlinear(linear.r),
+        srgb_unlinear(linear.g),
+        srgb_unlinear(linear.b),
+        linear.a
+    );
 }

--- a/mm-server/src/compositor/video/composite.rs
+++ b/mm-server/src/compositor/video/composite.rs
@@ -12,7 +12,7 @@ use crate::vulkan::*;
 
 use super::SurfaceTexture;
 
-pub const BLEND_FORMAT: vk::Format = vk::Format::B8G8R8A8_SRGB;
+pub const BLEND_FORMAT: vk::Format = vk::Format::R16G16B16A16_SFLOAT;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]

--- a/mm-server/src/compositor/video/composite.rs
+++ b/mm-server/src/compositor/video/composite.rs
@@ -12,7 +12,7 @@ use crate::vulkan::*;
 
 use super::SurfaceTexture;
 
-pub const BLEND_FORMAT: vk::Format = vk::Format::B8G8R8A8_UNORM;
+pub const BLEND_FORMAT: vk::Format = vk::Format::B8G8R8A8_SRGB;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]

--- a/mm-server/src/compositor/video/shaders/composite_frag.glsl
+++ b/mm-server/src/compositor/video/shaders/composite_frag.glsl
@@ -10,6 +10,41 @@ layout(location = 0) in vec2 uv;
 
 layout(location = 0) out vec4 color;
 
+float srgb_channel_to_linear(float x) {
+    return mix(x / 12.92,
+        pow((x + 0.055) / 1.055, 2.4),
+        x > 0.04045);
+}
+
+vec4 srgb_to_linear(vec4 color) {
+	if (color.a == 0) {
+		return vec4(0);
+	}
+
+	color.rgb /= color.a;
+	color.rgb = vec3(
+		srgb_channel_to_linear(color.r),
+		srgb_channel_to_linear(color.g),
+		srgb_channel_to_linear(color.b)
+	);
+
+	color.rgb *= color.a;
+	return color;
+}
+
 void main() {
-    color = texture(tex, uv);
+    vec4 tex_color = texture(tex, uv);
+
+    // Wayland specifies that textures have premultiplied alpha. If we just
+    // import a dmabuf as sRGB, the colors are wrong, since vulkan expects sRGB
+    // textures to have not-premultiplied alpha.
+    //
+    // Vulkan normally expects to do the sRGB -> linear conversion when sampling
+    // in the shader. However, we're bypassing that operation here, by importing
+    // the texture as UNORM (even though it's stored as sRGB) and then doing the
+    // conversion manually.
+    //
+    // TODO: For imported textures with no alpha channel (XR24), we should skip
+    // this and use a sRGB view into the texture instead.
+    color = srgb_to_linear(tex_color);
 }

--- a/mm-server/src/compositor/video/shaders/convert.glsl
+++ b/mm-server/src/compositor/video/shaders/convert.glsl
@@ -32,6 +32,17 @@ vec3 rgb_to_ycbcr(vec3 color) {
     );
 }
 
+float rgb709_unlinear(float s) {
+    return mix(4.5*s, 1.099*pow(s, 1.0/2.2) - 0.099, s >= 0.018);
+}
+
+vec3 unlinearize(vec3 color) {
+    return vec3(
+        rgb709_unlinear(color.r),
+        rgb709_unlinear(color.g),
+        rgb709_unlinear(color.b));
+}
+
 void main() {
     vec2 self_id = gl_GlobalInvocationID.xy;
     ivec2 coords = ivec2(self_id.x*2, self_id.y*2);
@@ -44,7 +55,7 @@ void main() {
         for(j = 0; j < 2; j += 1) {
             ivec2 texel_coords = coords + ivec2(j, k);
             vec4 texel = texelFetch(blend_image, texel_coords, 0);
-            vec3 yuv = rgb_to_ycbcr(texel.rgb);
+            vec3 yuv = rgb_to_ycbcr(unlinearize(texel.rgb));
     
             imageStore(luminance, texel_coords, vec4(yuv.x));
             


### PR DESCRIPTION
Dmabufs, when they come to us from the application, are usually stored as sRGB, with premultiplied alpha. To blend correctly, we need to convert them to linear. We can't just specify _SRGB formats when importing, because wayland requires premultiplied alpha in buffers, and vulkan's SRGB formats assume straight alpha.

However, fixing that uncovered a second problem, which is that we were doing the YCbCr conversion on linear color values, rather than color values already in the rec.709 color space. This happened to work because we were skipping a conversion (to linear) on the import side and also skipping a conversion (to 709) on the conversion side. However, it was only mostly correct; sRGB and 709 have the same color primaries, but different transfer functions.