### PR TITLE
Native linux containerization

### DIFF
--- a/mm-protocol/src/messages.proto
+++ b/mm-protocol/src/messages.proto
@@ -1099,8 +1099,10 @@ message GamepadMotion {
   uint64 gamepad_id = 1; // Required.
   GamepadAxis axis = 2;  // Required.
 
-  // Required, with a value from -1.0 to 1.0. Zero always represents the resting
-  // position, and triggers will therefore usually range from 0.0 to 1.0.
+  // Required, with a value from -1.0 (towards the top of the gamepad) to 1.0
+  // (towards the bottom of the gamepad). Zero always represents the resting
+  // position, and triggers will therefore usually range from 0.0 to 1.0
+  // (fully pressed).
   double value = 3;
 }
 

--- a/mm-server/Cargo.lock
+++ b/mm-server/Cargo.lock
@@ -165,6 +165,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +628,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +761,20 @@ checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fuser"
+version = "0.14.0"
+source = "git+https://github.com/colinmarc/fuser?rev=1e22afdb868a86afd20ce598aec6e634a9fdc603#1e22afdb868a86afd20ce598aec6e634a9fdc603"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.28.0",
+ "page_size",
+ "smallvec",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -938,6 +999,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1146,7 @@ dependencies = [
  "drm-fourcc",
  "ffmpeg-next",
  "ffmpeg-sys-next",
+ "fuser",
  "git-version",
  "glam",
  "hashbrown",
@@ -1082,7 +1160,9 @@ dependencies = [
  "mio-timerfd",
  "mktemp",
  "mm-protocol",
+ "murmur3",
  "nix 0.29.0",
+ "num_enum",
  "octets",
  "oneshot",
  "opus",
@@ -1103,8 +1183,10 @@ dependencies = [
  "simple_moving_average",
  "slang",
  "slotmap",
+ "southpaw",
  "svt",
  "system-deps",
+ "test-log",
  "thiserror",
  "threadpool",
  "tiny_id",
@@ -1113,6 +1195,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tracy",
  "tracy-client",
+ "uds",
  "unshare",
  "uuid",
  "wayland-protocols",
@@ -1127,6 +1210,12 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "nix"
@@ -1212,6 +1301,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "octets"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1354,39 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "paste"
@@ -1345,6 +1488,15 @@ checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1527,6 +1679,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1803,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
@@ -1760,6 +1933,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "southpaw"
+version = "0.1.0"
+dependencies = [
+ "bindgen 0.70.1",
+ "bit-vec",
+ "fuser",
+ "libc",
+ "litemap",
+ "log",
+ "num_enum",
+ "parking_lot",
+ "rustix",
+ "semver",
+ "seq-macro",
+ "thunderdome",
+ "uapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,6 +2058,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,6 +2117,12 @@ checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
 ]
+
+[[package]]
+name = "thunderdome"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e170f93360bf9ae6fe3c31116bbf27adb1d054cedd6bc3d7857e34f2d98d0b"
 
 [[package]]
 name = "time"
@@ -2085,6 +2305,15 @@ dependencies = [
  "quote",
  "regex",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "uds"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885c31f06fce836457fe3ef09a59f83fe8db95d270b11cd78f40a4666c4d1661"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2588,6 +2817,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive 0.7.35",
 ]
 

--- a/mm-server/Cargo.lock
+++ b/mm-server/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.72",
  "which",
 ]
 
@@ -316,7 +316,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -324,6 +324,16 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "clone3"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4e061ea30800291ca09663878f3953840a69b08ce244b3e8b26e894d9f60f"
+dependencies = [
+ "bitflags 1.2.1",
+ "uapi",
+]
 
 [[package]]
 name = "cmake"
@@ -357,7 +367,7 @@ checksum = "ecd76a074597402da6c7e3a21c35c7c9476ff4fde254942d78ce7bda8673059a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -588,7 +598,7 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -681,7 +691,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -757,7 +767,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1049,6 +1059,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "clap",
+ "clone3",
  "converge",
  "crossbeam-channel",
  "cstr",
@@ -1333,7 +1344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1372,7 +1383,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.72",
  "tempfile",
 ]
 
@@ -1386,7 +1397,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1649,7 +1660,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1803,6 +1814,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
@@ -1860,7 +1882,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1966,7 +1988,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2037,6 +2059,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98b98232a2447ce0a58f9a0bfb5f5e39647b5c597c994b63945fcccd1306fafb"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "uapi"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf073840d1b16485bfe28b4e752eccee38d9ac53f152adf869708e3136561e6"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "uapi-proc",
+]
+
+[[package]]
+name = "uapi-proc"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54de46f980cea7b2ae8d8f7f9f1c35cf7062c68343e99345ef73758f8e60975a"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2133,7 +2181,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -2155,7 +2203,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2304,7 +2352,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2315,7 +2363,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2551,7 +2599,7 @@ checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2562,5 +2610,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]

--- a/mm-server/Cargo.lock
+++ b/mm-server/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 [[package]]
 name = "fuser"
 version = "0.14.0"
-source = "git+https://github.com/colinmarc/fuser?rev=1e22afdb868a86afd20ce598aec6e634a9fdc603#1e22afdb868a86afd20ce598aec6e634a9fdc603"
+source = "git+https://github.com/colinmarc/fuser?rev=643facdc1bcc9a3b11d7a88ebfaaaa045c3596c1#643facdc1bcc9a3b11d7a88ebfaaaa045c3596c1"
 dependencies = [
  "libc",
  "log",
@@ -1934,7 +1934,8 @@ dependencies = [
 
 [[package]]
 name = "southpaw"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/colinmarc/southpaw?rev=ff78fa6ce7e82c8afa5f7e365194ac083ce743b3#ff78fa6ce7e82c8afa5f7e365194ac083ce743b3"
 dependencies = [
  "bindgen 0.70.1",
  "bit-vec",

--- a/mm-server/Cargo.toml
+++ b/mm-server/Cargo.toml
@@ -33,7 +33,7 @@ boring = "3"
 rand = "0.8.5"
 ring = "0.16.20"
 rustix = { version = "0.38", default-features = false, features = ["mm", "mount", "pipe", "time", "thread", "stdio"] }
-southpaw = { path = "../../southpaw" }
+southpaw = { git = "https://github.com/colinmarc/southpaw", rev = "ff78fa6ce7e82c8afa5f7e365194ac083ce743b3" }
 thiserror = "1.0.48"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
@@ -84,7 +84,7 @@ rev = "92084df65f52aa15b704279fb6d8d26a3ee71809"
 
 [dependencies.fuser]
 git = "https://github.com/colinmarc/fuser"
-rev = "1e22afdb868a86afd20ce598aec6e634a9fdc603"
+rev = "643facdc1bcc9a3b11d7a88ebfaaaa045c3596c1"
 default-features = false
 
 [dependencies.pulseaudio]

--- a/mm-server/Cargo.toml
+++ b/mm-server/Cargo.toml
@@ -22,7 +22,9 @@ glam = "0.24.1"
 lazy_static = "1.4.0"
 libc = "0.2"
 libloading = "0.8.0"
+murmur3 = "0.5"
 nix = { version = "0.29", features = ["net", "socket", "uio"] }
+num_enum = "0.7"
 mio = { version = "1", features = ["net", "os-ext", "os-poll"] }
 mio-timerfd = "0.2.0"
 quiche = { version = "0.18", features = ["boringssl-boring-crate"] }
@@ -30,10 +32,12 @@ rcgen = "0.12.1"
 boring = "3"
 rand = "0.8.5"
 ring = "0.16.20"
-rustix = { version = "0.38", features = ["mm", "mount", "pipe", "time", "stdio"] }
+rustix = { version = "0.38", default-features = false, features = ["mm", "mount", "pipe", "time", "thread", "stdio"] }
+southpaw = { path = "../../southpaw" }
 thiserror = "1.0.48"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+uds = "0.4"
 mm-protocol = { path = "../mm-protocol" }
 octets = "0.2.0"
 protobuf = "3.2.0"
@@ -78,6 +82,11 @@ x11rb = { version = "0.13", features = ["composite"] }
 git = "https://github.com/ash-rs/ash"
 rev = "92084df65f52aa15b704279fb6d8d26a3ee71809"
 
+[dependencies.fuser]
+git = "https://github.com/colinmarc/fuser"
+rev = "1e22afdb868a86afd20ce598aec6e634a9fdc603"
+default-features = false
+
 [dependencies.pulseaudio]
 git = "https://github.com/colinmarc/pulseaudio-rs"
 rev = "70ddb748f20ceecc20e963e571188124aeb30186"
@@ -87,7 +96,6 @@ git = "https://github.com/colinmarc/svt-rs"
 rev = "747915fa4b2f7d0bd2c70ef5af108c75031efc53"
 optional = true
 features = ["av1", "hevc"]
-
 
 [build-dependencies]
 system-deps = "6"

--- a/mm-server/Cargo.toml
+++ b/mm-server/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.72"
 bytes = "1.4.0"
+clone3 = "0.2"
 cstr = "0.2.11"
 ffmpeg-next = { version = "7", optional = true }
 ffmpeg-sys-next = { version = "7", optional = true }
@@ -29,7 +30,7 @@ rcgen = "0.12.1"
 boring = "3"
 rand = "0.8.5"
 ring = "0.16.20"
-rustix = { version = "0.38", features = ["mm", "time"] }
+rustix = { version = "0.38", features = ["mm", "mount", "pipe", "time", "stdio"] }
 thiserror = "1.0.48"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
@@ -114,7 +115,8 @@ tracy = [
 ]
 
 [dev-dependencies]
-pretty_assertions = "1.4.0"
+pretty_assertions = "*"
+test-log = { version = "*", features = ["trace"] }
 
 [patch.crates-io]
 mio-timerfd = { git = "https://github.com/colinmarc/mio-timerfd.git" }

--- a/mm-server/src/compositor/child/container.rs
+++ b/mm-server/src/compositor/child/container.rs
@@ -1,0 +1,859 @@
+// Copyright 2024 Colin Marc <hi@colinmarc.com>
+//
+// SPDX-License-Identifier: BUSL-1.1
+
+use std::{
+    ffi::{CStr, CString, OsStr, OsString},
+    fs::OpenOptions,
+    io,
+    os::{
+        fd::{AsFd, AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd},
+        unix::process::CommandExt as _,
+    },
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr as _,
+    time,
+};
+
+use anyhow::{anyhow, Context as _};
+use pathsearch::find_executable_in_path;
+use rand::distributions::{Alphanumeric, DistString as _};
+use rustix::{
+    fs::{mkdirat, openat, symlinkat, FileType, Gid, Mode, OFlags, Uid, CWD as AT_FDCWD},
+    io::{fcntl_dupfd_cloexec, write, Errno},
+    mount::{
+        fsconfig_create, fsconfig_set_flag, fsconfig_set_string, fsmount, fsopen, move_mount,
+        open_tree, FsMountFlags, FsOpenFlags, MountAttrFlags, MoveMountFlags, OpenTreeFlags,
+    },
+    process::{getgid, getuid, set_parent_process_death_signal, waitpid, Pid, Signal, WaitOptions},
+    thread::{move_into_link_name_space, LinkNameSpaceType},
+};
+use tracing::debug;
+
+use crate::config::{self, AppConfig};
+
+mod ipc;
+
+#[derive(Debug, Clone, Copy)]
+struct DevBindMount {
+    path: &'static str,
+    is_dir: bool,
+}
+
+const DEV_BIND_MOUNTS: &[DevBindMount] = &[
+    DevBindMount {
+        path: "/dev/null",
+        is_dir: false,
+    },
+    DevBindMount {
+        path: "/dev/zero",
+        is_dir: false,
+    },
+    DevBindMount {
+        path: "/dev/full",
+        is_dir: false,
+    },
+    DevBindMount {
+        path: "/dev/tty",
+        is_dir: false,
+    },
+    DevBindMount {
+        path: "/dev/random",
+        is_dir: false,
+    },
+    DevBindMount {
+        path: "/dev/urandom",
+        is_dir: false,
+    },
+    DevBindMount {
+        path: "/dev/dri",
+        is_dir: true,
+    },
+    DevBindMount {
+        path: "/dev/fuse",
+        is_dir: false,
+    },
+];
+
+struct UnbufferedStderr<'a>(BorrowedFd<'a>);
+
+impl<'a> std::fmt::Write for UnbufferedStderr<'a> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        write(self.0, s.as_bytes()).map_err(|_| std::fmt::Error)?;
+        Ok(())
+    }
+}
+
+#[cfg(debug_assertions)]
+macro_rules! preexec_debug {
+    ($($arg:tt)+) => {
+        #[allow(unused_imports)]
+        use std::fmt::Write as _;
+
+        let mut stderr = UnbufferedStderr(rustix::stdio::stderr());
+        let _ = std::write!(stderr, "[PRE-EXEC] ");
+        let _ = std::writeln!(stderr, $($arg)*);
+    }
+}
+
+#[cfg(not(debug_assertions))]
+macro_rules! preexec_debug {
+    ($($arg:tt)*) => {};
+}
+
+unsafe fn _must<T>(op: &str, res: rustix::io::Result<T>) -> T {
+    loop {
+        match res {
+            Ok(v) => return v,
+            Err(Errno::INTR) => continue,
+            Err(e) => {
+                #[cfg(debug_assertions)]
+                {
+                    use std::fmt::Write as _;
+                    let mut stderr = UnbufferedStderr(rustix::stdio::stderr());
+
+                    let _ = std::writeln!(stderr, "[PRE-EXEC] {op}: {e}");
+                    let _ = std::writeln!(stderr);
+                }
+
+                std::process::abort();
+            }
+        }
+    }
+}
+
+macro_rules! must {
+    ($n:ident( $($args:tt)* )) => {{
+        let res = $n( $($args)* );
+        _must(stringify!($n), res)
+    }};
+}
+
+type SetupHook = Box<dyn FnOnce(&mut super::ChildHandle) -> anyhow::Result<()>>;
+
+/// A lightweight linux container. Currently we use the following namespaces:
+///  - A mount namespace, to mount tmpfs on /dev, /tmp, /run, etc, and
+///    potentially to isolate home as well. We don't pivot_root/chroot.
+///  - A PID namespace, so that processes get cleaned up when a session ends.
+///    Note that we currently don't use a "stub init" process to handle
+///    reparenting or reaping, since we don't expect to spawn lots of grandchild
+///    processes.
+///  - A user namespace, to enable the above. We just map the current user to
+///    itself.
+///
+/// IMPORTANT: This container is not a secure container. Under NO CIRCUMSTANCES
+/// should you use it to run untrusted code. Any security benefits are purely
+/// incidental; this is more about containing mess (I'm looking at you, Steam).
+pub struct Container {
+    child_cmd: Command,
+
+    // Note: we don't use Command::env or Command::env_clear, because those
+    // cause Command::exec to allocate, which we don't want to do after forking.
+    envs: Vec<(OsString, OsString)>,
+
+    tmp_stderr: Option<OwnedFd>,
+
+    extern_home_path: Option<PathBuf>,
+    intern_home_path: PathBuf,
+    clear_home: bool,
+
+    intern_run_path: PathBuf,
+    extern_run_path: PathBuf,
+
+    additional_bind_mounts: Vec<(PathBuf, PathBuf)>,
+    internal_bind_mounts: Vec<(PathBuf, PathBuf, bool)>,
+
+    // Stores a closure to run before unfreeze.
+    setup_hooks: Vec<SetupHook>,
+
+    uid: Uid,
+    gid: Gid,
+}
+
+impl Container {
+    pub fn new(app_config: AppConfig) -> anyhow::Result<Self> {
+        let mut args = app_config.command.clone();
+        let exe = args.remove(0);
+        let exe_path =
+            find_executable_in_path(&exe).ok_or(anyhow!("command {:?} not in PATH", &exe))?;
+
+        let mut envs: Vec<(OsString, OsString)> = app_config.env.clone().into_iter().collect();
+
+        let mut child_cmd = Command::new(exe_path);
+        child_cmd.current_dir("/");
+        child_cmd.args(args);
+
+        if let Some(path) = std::env::var_os("PATH") {
+            envs.push(("PATH".into(), path));
+        }
+
+        let uid = getuid();
+        let gid = getgid();
+
+        let intern_run_path: OsString = format!("/run/user/{}", uid.as_raw()).try_into().unwrap();
+        envs.push(("XDG_RUNTIME_DIR".into(), intern_run_path.clone()));
+
+        let extern_run_path = std::env::temp_dir().join(format!(
+            "mm.{}",
+            Alphanumeric.sample_string(&mut rand::thread_rng(), 16),
+        ));
+        std::fs::create_dir_all(&extern_run_path)?;
+
+        let intern_home_path: OsString = std::env::var_os("HOME").unwrap_or("/home/mm".into());
+        envs.push(("HOME".into(), intern_home_path.clone()));
+
+        debug!(home_mode = ?app_config.home_isolation_mode, "using home mode");
+        let (extern_home_path, clear_home) = match app_config.home_isolation_mode {
+            config::HomeIsolationMode::Unisolated => (None, false),
+            config::HomeIsolationMode::Tmpfs => (None, true),
+            config::HomeIsolationMode::Permanent(path) => {
+                std::fs::create_dir_all(&path).context(format!(
+                    "failed to create home directory {}",
+                    path.display()
+                ))?;
+
+                (Some(path), true)
+            }
+        };
+
+        Ok(Self {
+            child_cmd,
+            envs,
+            tmp_stderr: None,
+
+            intern_home_path: intern_home_path.into(),
+            extern_home_path,
+            clear_home,
+            intern_run_path: intern_run_path.into(),
+            extern_run_path,
+
+            additional_bind_mounts: Vec::new(),
+            internal_bind_mounts: Vec::new(),
+
+            setup_hooks: Vec::new(),
+
+            uid,
+            gid,
+        })
+    }
+
+    pub fn intern_run_path(&self) -> &Path {
+        &self.intern_run_path
+    }
+
+    pub fn extern_run_path(&self) -> &Path {
+        &self.extern_run_path
+    }
+
+    pub fn bind_mount(&mut self, src: impl AsRef<Path>, dst: impl AsRef<Path>) {
+        self.additional_bind_mounts
+            .push((src.as_ref().to_owned(), dst.as_ref().to_owned()));
+    }
+
+    pub fn internal_bind_mount(&mut self, src: impl AsRef<Path>, dst: impl AsRef<Path>) {
+        self.internal_bind_mounts
+            .push((src.as_ref().to_owned(), dst.as_ref().to_owned(), true));
+    }
+
+    pub fn setup_hook(
+        &mut self,
+        f: impl FnOnce(&mut super::ChildHandle) -> anyhow::Result<()> + 'static,
+    ) {
+        self.setup_hooks.push(Box::new(f))
+    }
+
+    pub fn set_env<K, V>(&mut self, key: K, val: V)
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.envs
+            .push((key.as_ref().to_owned(), val.as_ref().to_owned()))
+    }
+
+    pub fn set_stdout<T: AsFd>(&mut self, stdio: T) -> anyhow::Result<()> {
+        let stdout = fcntl_dupfd_cloexec(&stdio, 0)?;
+        self.child_cmd.stdout(stdout);
+
+        Ok(())
+    }
+
+    pub fn set_stderr<T: AsFd>(&mut self, stdio: T) -> anyhow::Result<()> {
+        let stderr = fcntl_dupfd_cloexec(&stdio, 0)?;
+        let tmp_stderr = fcntl_dupfd_cloexec(&stdio, 0)?;
+
+        self.child_cmd.stderr(stderr);
+        self.tmp_stderr = Some(tmp_stderr);
+
+        Ok(())
+    }
+
+    pub fn spawn(mut self) -> anyhow::Result<super::ChildHandle> {
+        // Prepare bind mounts.
+        let mut mounts = DEV_BIND_MOUNTS
+            .iter()
+            .map(|m| {
+                Ok((
+                    PathBuf::from_str(m.path).unwrap(),
+                    PathBuf::from_str(m.path).unwrap(),
+                    m.is_dir,
+                    None,
+                ))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        for (src, dst) in self.additional_bind_mounts.drain(..) {
+            let is_dir = std::fs::metadata(&src)
+                .context("failed to stat bind mount")?
+                .is_dir();
+
+            mounts.push((src, dst, is_dir, None))
+        }
+
+        let mut child_pidfd = -1;
+        let mut args = clone3::Clone3::default();
+        args.flag_pidfd(&mut child_pidfd)
+            .exit_signal(libc::SIGCHLD as _)
+            .flag_newuser()
+            .flag_newns()
+            .flag_newpid();
+
+        // TODO
+        self.child_cmd.env_clear().envs(self.envs.clone());
+        debug!(cmd = ?self.child_cmd, "spawning child process");
+
+        let (barrier, child_barrier) = ipc::EventfdBarrier::new()?;
+
+        // clone off a child process, which does some setup before execing the
+        // app.
+        let child_stderr = self.tmp_stderr.take();
+        let child_pid = match unsafe { args.call().context("clone3")? } {
+            0 => unsafe {
+                self.child_after_fork(child_stderr.as_ref(), child_barrier, &mut mounts)
+            },
+            pid => pid,
+        };
+
+        let child_pidfd = unsafe { OwnedFd::from_raw_fd(child_pidfd) };
+
+        set_uid_map(child_pid, self.uid, self.gid).context("failed to set uid/gid map")?;
+
+        // Wait for the child to signal that it's ready.
+        barrier
+            .sync(time::Duration::from_secs(1))
+            .context("timed out waiting for forked child (phase 1)")?;
+
+        let mut handle = super::ChildHandle {
+            pid: Pid::from_raw(child_pid).unwrap(),
+            pidfd: child_pidfd,
+            run_path: self.extern_run_path,
+        };
+
+        for hook in self.setup_hooks.drain(..) {
+            hook(&mut handle)?;
+        }
+
+        // Unfreeze the child.
+        barrier
+            .sync(time::Duration::from_secs(1))
+            .context("timed out waiting for forked child (phase 2)")?;
+
+        Ok(handle)
+    }
+
+    // Signal safety dictates what we can do here, and it's not a lot. The main
+    // thing we avoid is allocations. Note that rustix is added as a dependency
+    // without the 'alloc' feature.
+    unsafe fn child_after_fork<FD>(
+        mut self,
+        stderr: Option<FD>,
+        barrier: ipc::EventfdBarrier,
+        bind_mounts: &mut [(PathBuf, PathBuf, bool, Option<OwnedFd>)],
+    ) -> !
+    where
+        FD: AsFd,
+    {
+        // See above for how logging is implemented to avoid the possibility of
+        // allocation.
+        if let Some(fd) = &stderr {
+            let _ = rustix::stdio::dup2_stderr(fd.as_fd()); // Replace stderr.
+        }
+
+        // Tell the kernel to SIGKILL us when our parent (mmserver) dies. this
+        // is particularly important because we're PID 1, so the kernel won't
+        // kill on SIGINT/SIGQUIT/etc if the child process doesn't have a signal
+        // handler set up for them.
+        must!(set_parent_process_death_signal(Some(Signal::Kill)));
+
+        preexec_debug!("starting container setup");
+
+        // Mount /proc first.
+        must!(mount_fs(
+            c"proc",
+            c"/proc",
+            MountAttrFlags::MOUNT_ATTR_NOEXEC
+                | MountAttrFlags::MOUNT_ATTR_NOSUID
+                | MountAttrFlags::MOUNT_ATTR_NODEV,
+            &[],
+        ));
+
+        // Collect detached mounts we want to bind-mount later. We can't
+        // allocate a vec, so we fill in the Options in the passed-in vec
+        // instead.
+        preexec_debug!("collecting detached bind mounts");
+        for (src_path, _, _, ref mut device_fd) in bind_mounts.iter_mut() {
+            let fd = must!(detach_mount(src_path,));
+
+            *device_fd = Some(fd)
+        }
+
+        // Grab a detached mount for the temporary dir we're going to mount as
+        // XDG_RUNTIME_DIR.
+        let detached_run_fd = must!(detach_mount(&self.extern_run_path,));
+
+        // Grab a detached mount for home, if we're using one.
+        let detached_home = self
+            .extern_home_path
+            .as_ref()
+            .map(|p| must!(detach_mount(p)));
+
+        // Mount /dev and a few other filesystems.
+        must!(mount_fs(
+            c"tmpfs",
+            c"/dev",
+            MountAttrFlags::MOUNT_ATTR_NOEXEC | MountAttrFlags::MOUNT_ATTR_STRICTATIME,
+            &[(c"mode", c"0755")],
+        ));
+
+        must!(mount_fs(
+            c"tmpfs",
+            c"/dev/shm",
+            MountAttrFlags::MOUNT_ATTR_NOEXEC
+                | MountAttrFlags::MOUNT_ATTR_NOSUID
+                | MountAttrFlags::MOUNT_ATTR_NODEV,
+            &[(c"mode", c"1777"), (c"size", c"512m")],
+        ));
+
+        // TODO: this errors with EPERM.
+        // must!(mount_fs(
+        //     "mqueue",
+        //     "/dev/mqueue",
+        //     MountAttrFlags::MOUNT_ATTR_NOEXEC
+        //         | MountAttrFlags::MOUNT_ATTR_NOSUID
+        //         | MountAttrFlags::MOUNT_ATTR_NODEV,
+        //     &[],
+        // ));
+
+        must!(mount_fs(
+            c"devpts",
+            c"/dev/pts",
+            MountAttrFlags::MOUNT_ATTR_NOEXEC | MountAttrFlags::MOUNT_ATTR_NOSUID,
+            &[
+                (c"newinstance", c""),
+                (c"ptmxmode", c"0666"),
+                (c"mode", c"0620"),
+                // TODO: do we need to add a tty group?
+                // ("gid", "5"),
+            ],
+        ));
+
+        // Symlink /dev/fd -> /proc/self/fd, etc.
+        must!(symlinkat(c"/proc/self/fd", AT_FDCWD, c"/dev/fd"));
+        must!(symlinkat(c"/proc/self/fd/0", AT_FDCWD, c"/dev/stdin"));
+        must!(symlinkat(c"/proc/self/fd/1", AT_FDCWD, c"/dev/stdout"));
+        must!(symlinkat(c"/proc/self/fd/2", AT_FDCWD, c"/dev/stderr"));
+
+        // Prepare /dev/input.
+        must!(mkdirat(
+            AT_FDCWD,
+            "/dev/input",
+            Mode::from_bits(0o755).unwrap()
+        ));
+
+        must!(mount_fs(
+            c"tmpfs",
+            c"/run",
+            MountAttrFlags::MOUNT_ATTR_NOSUID
+                | MountAttrFlags::MOUNT_ATTR_NODEV
+                | MountAttrFlags::MOUNT_ATTR_RELATIME,
+            &[(c"mode", c"0700"), (c"size", c"1g")],
+        ));
+
+        must!(mkdirat(
+            AT_FDCWD,
+            "/run/user",
+            Mode::from_bits(0o700).unwrap()
+        ));
+
+        must!(mount_fs(
+            c"tmpfs",
+            c"/tmp",
+            MountAttrFlags::MOUNT_ATTR_NOSUID
+                | MountAttrFlags::MOUNT_ATTR_NOEXEC
+                | MountAttrFlags::MOUNT_ATTR_NOATIME,
+            &[(c"mode", c"0777"), (c"size", c"1g")],
+        ));
+
+        if self.clear_home {
+            must!(mount_fs(
+                c"tmpfs",
+                c"/home",
+                MountAttrFlags::MOUNT_ATTR_NOSUID
+                    | MountAttrFlags::MOUNT_ATTR_NOEXEC
+                    | MountAttrFlags::MOUNT_ATTR_NOATIME,
+                &[(c"mode", c"0777"), (c"size", c"1g")],
+            ));
+
+            must!(mkdirat(
+                AT_FDCWD,
+                &self.intern_home_path,
+                Mode::from_bits(0o700).unwrap()
+            ));
+        }
+
+        // Mount XDG_RUNTIME_DIR.
+        preexec_debug!(
+            "bind-mounting {} to {}",
+            self.extern_run_path.display(),
+            self.intern_run_path.display()
+        );
+
+        must!(mkdirat(AT_FDCWD, &self.intern_run_path, Mode::empty()));
+        must!(reattach_mount(detached_run_fd, &self.intern_run_path));
+
+        // Mount HOME.
+        if let Some(fd) = detached_home {
+            preexec_debug!(
+                "bind-mounting {} to {}",
+                self.extern_home_path.as_ref().unwrap().display(),
+                self.intern_home_path.display()
+            );
+
+            must!(reattach_mount(fd, &self.intern_home_path));
+        }
+
+        // Attach detached bind mounts, now that the filesystem is prepared.
+        for (_src_path, dst_path, is_dir, mount_fd) in bind_mounts {
+            preexec_debug!(
+                "bind-mounting {} (outside) to {} (inside)",
+                _src_path.display(),
+                dst_path.display()
+            );
+
+            let detached_mount_fd = mount_fd.take().unwrap();
+
+            if *is_dir {
+                let _ = mkdirat(AT_FDCWD, &*dst_path, Mode::empty());
+            } else {
+                must!(touch(&*dst_path, Mode::empty()));
+            }
+
+            must!(reattach_mount(detached_mount_fd, dst_path));
+        }
+
+        preexec_debug!("finished initial setup, waiting for mmserver");
+
+        // Sync with mmserver.
+        must!(sync_barrier(&barrier));
+        must!(sync_barrier(&barrier));
+
+        // Finally, internal bind mounts. We do this after syncing with mmserver
+        // in case mmserver wants us to bind-mount something it just mounted.
+        for (src_path, dst_path, is_dir) in &self.internal_bind_mounts {
+            preexec_debug!(
+                "bind-mounting {} to {}",
+                src_path.display(),
+                dst_path.display()
+            );
+
+            let fd = must!(detach_mount(src_path));
+
+            if *is_dir {
+                let _ = mkdirat(AT_FDCWD, dst_path, Mode::empty());
+            } else {
+                must!(touch(dst_path, Mode::empty()));
+            }
+
+            must!(reattach_mount(fd, dst_path));
+        }
+
+        // TODO: Install seccomp handlers here.
+
+        // We don't trust std::os::Command's env handling, because sometimes
+        // it allocates.
+        // libc::clearenv();
+        // for (k, v) in &self.envs {
+        //     libc::setenv
+        // }
+
+        // If successful, this never returns.
+        let e = self.child_cmd.exec();
+
+        preexec_debug!("execve failed: {e}");
+        std::process::abort();
+    }
+}
+
+fn set_uid_map(child_pid: i32, uid: rustix::fs::Uid, gid: rustix::fs::Gid) -> anyhow::Result<()> {
+    let uid = uid.as_raw();
+    let gid = gid.as_raw();
+
+    write(
+        OpenOptions::new()
+            .write(true)
+            .open(format!("/proc/{}/setgroups", child_pid))?,
+        b"deny",
+    )
+    .context("failed to write setgroups=deny")?;
+
+    write(
+        OpenOptions::new()
+            .write(true)
+            .open(format!("/proc/{}/uid_map", child_pid))
+            .context("open failed")?,
+        format!("{uid} {uid} 1\n").as_bytes(),
+    )
+    .context("failed to write uid_map")?;
+
+    write(
+        OpenOptions::new()
+            .write(true)
+            .open(format!("/proc/{}/gid_map", child_pid))
+            .context("open failed")?,
+        format!("{gid} {gid} 1\n").as_bytes(),
+    )
+    .context("failed to write gid_map")?;
+
+    Ok(())
+}
+
+fn run_in_container<F>(ns_pidfd: impl AsFd, stderr: Option<BorrowedFd<'_>>, f: F) -> io::Result<()>
+where
+    F: FnOnce() -> io::Result<()>,
+{
+    let child_pid = unsafe { libc::fork() };
+    if child_pid == -1 {
+        return Err(io::Error::last_os_error());
+    } else if child_pid == 0 {
+        unsafe {
+            if let Some(fd) = &stderr {
+                let _ = rustix::stdio::dup2_stderr(fd.as_fd()); // Replace stderr.
+            }
+
+            must!(set_parent_process_death_signal(Some(Signal::Kill)));
+
+            must!(move_into_link_name_space(
+                ns_pidfd.as_fd(),
+                Some(LinkNameSpaceType::User)
+            ));
+
+            must!(move_into_link_name_space(
+                ns_pidfd.as_fd(),
+                Some(LinkNameSpaceType::Mount)
+            ));
+
+            if let Err(e) = f() {
+                preexec_debug!("run_in_container: {e}");
+                libc::exit(1);
+            }
+
+            libc::exit(0);
+        }
+    }
+
+    loop {
+        match waitpid(
+            Some(Pid::from_raw(child_pid).unwrap()),
+            WaitOptions::empty(),
+        ) {
+            Ok(st) => match st {
+                Some(st) if st.as_raw() == 0 => return Ok(()),
+                _ => return Err(io::Error::other("forked process exited with error")),
+            },
+            Err(Errno::INTR) => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+pub(super) fn fuse_mount(
+    ns_pidfd: impl AsFd,
+    dst: impl AsRef<Path>,
+    fsname: String,
+    st_mode: u32,
+) -> io::Result<OwnedFd> {
+    debug!("mounting {fsname} to {}", dst.as_ref().display());
+
+    let (fd_tx, fd_rx) = ipc::fd_oneshot()?;
+    let uid = CString::new(format!("{}", getuid().as_raw())).unwrap();
+    let gid = CString::new(format!("{}", getuid().as_raw())).unwrap();
+    let rootmode = CString::new(format!("{st_mode:o}")).unwrap();
+
+    let is_dir = FileType::from_raw_mode(st_mode) == FileType::Directory;
+
+    run_in_container(ns_pidfd, None, move || {
+        let fuse_device_fd = openat(
+            AT_FDCWD,
+            "/dev/fuse",
+            OFlags::RDWR | OFlags::CLOEXEC,
+            Mode::empty(),
+        )?;
+
+        // Send the fd back to mmserver.
+        fd_tx.send_timeout(fuse_device_fd.try_clone()?, time::Duration::from_secs(1))?;
+
+        // format! allocates.
+        let mut fd_buf = [0_u8; 32];
+        let fd_str = {
+            use std::io::Write;
+            write!(
+                &mut io::Cursor::new(&mut fd_buf[..]),
+                "{}",
+                fuse_device_fd.as_raw_fd()
+            )?;
+
+            CStr::from_bytes_until_nul(&fd_buf[..])
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid FD"))?
+        };
+
+        if is_dir {
+            let _ = mkdirat(AT_FDCWD, dst.as_ref(), Mode::from_raw_mode(st_mode));
+        } else {
+            let _ = touch(dst.as_ref(), Mode::from_raw_mode(st_mode));
+        }
+
+        let fsfd = fsopen(c"fuse", FsOpenFlags::FSOPEN_CLOEXEC)?;
+        fsconfig_set_string(fsfd.as_fd(), c"fd", fd_str)?;
+        fsconfig_set_string(fsfd.as_fd(), c"user_id", &uid)?;
+        fsconfig_set_string(fsfd.as_fd(), c"group_id", &gid)?;
+        fsconfig_set_string(fsfd.as_fd(), c"rootmode", &rootmode)?;
+        fsconfig_create(fsfd.as_fd())?;
+
+        let mount_fd = fsmount(
+            fsfd.as_fd(),
+            FsMountFlags::FSMOUNT_CLOEXEC,
+            MountAttrFlags::MOUNT_ATTR_NOEXEC
+                | MountAttrFlags::MOUNT_ATTR_NOSUID
+                | MountAttrFlags::MOUNT_ATTR_NODEV,
+        )?;
+
+        move_mount(
+            mount_fd.as_fd(),
+            c"",
+            AT_FDCWD,
+            dst.as_ref(),
+            MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH | MoveMountFlags::MOVE_MOUNT_T_EMPTY_PATH,
+        )?;
+
+        Ok(())
+    })?;
+
+    fd_rx.recv_timeout(time::Duration::from_secs(1))
+}
+
+fn touch(path: impl AsRef<Path>, mode: impl Into<Mode>) -> rustix::io::Result<()> {
+    let _ = openat(
+        AT_FDCWD,
+        path.as_ref(),
+        OFlags::WRONLY | OFlags::CREATE | OFlags::CLOEXEC,
+        mode.into(),
+    )?;
+
+    Ok(())
+}
+
+fn detach_mount(path: impl AsRef<Path>) -> rustix::io::Result<OwnedFd> {
+    open_tree(
+        AT_FDCWD,
+        path.as_ref(),
+        OpenTreeFlags::OPEN_TREE_CLONE
+            | OpenTreeFlags::AT_RECURSIVE
+            | OpenTreeFlags::OPEN_TREE_CLOEXEC,
+    )
+}
+
+fn reattach_mount(fd: OwnedFd, path: impl AsRef<Path>) -> rustix::io::Result<()> {
+    move_mount(
+        fd.as_fd(),
+        "",
+        AT_FDCWD,
+        path.as_ref(),
+        MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
+    )
+}
+
+fn mount_fs(
+    fstype: &CStr,
+    dst: &CStr,
+    options: MountAttrFlags,
+    configs: &[(&CStr, &CStr)],
+) -> rustix::io::Result<()> {
+    preexec_debug!("mounting {fstype:?} on {dst:?}");
+
+    let fsfd = fsopen(fstype, FsOpenFlags::FSOPEN_CLOEXEC)?;
+
+    for (k, v) in configs {
+        if v.is_empty() {
+            fsconfig_set_flag(fsfd.as_fd(), *k)?;
+        } else {
+            fsconfig_set_string(fsfd.as_fd(), *k, *v)?;
+        }
+    }
+
+    fsconfig_create(fsfd.as_fd())?;
+    let mount_fd = fsmount(fsfd.as_fd(), FsMountFlags::FSMOUNT_CLOEXEC, options)?;
+
+    let _ = mkdirat(AT_FDCWD, dst, Mode::empty());
+    move_mount(
+        mount_fd.as_fd(),
+        c"",
+        AT_FDCWD,
+        dst,
+        MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH | MoveMountFlags::MOVE_MOUNT_T_EMPTY_PATH,
+    )?;
+
+    Ok(())
+}
+
+// Wrapped in a function for compatibility with the must! macro.
+fn sync_barrier(barrier: &ipc::EventfdBarrier) -> rustix::io::Result<()> {
+    barrier.sync(time::Duration::from_secs(1))
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, fs::File, io::Read as _};
+
+    use rustix::pipe::{pipe_with, PipeFlags};
+
+    use crate::{
+        compositor::Container,
+        config::{AppConfig, HomeIsolationMode},
+    };
+
+    #[test_log::test]
+    fn echo() -> anyhow::Result<()> {
+        let app_config = AppConfig {
+            description: None,
+            command: vec!["echo".to_owned().into(), "done".to_owned().into()],
+            env: HashMap::new(),
+            xwayland: false,
+            force_1x_scale: false,
+            home_isolation_mode: HomeIsolationMode::Unisolated,
+        };
+
+        let mut container = Container::new(app_config)?;
+        let (pipe_rx, pipe_tx) = pipe_with(PipeFlags::CLOEXEC)?;
+        container.set_stdout(pipe_tx)?;
+
+        let mut child = container.spawn()?;
+        child.wait()?;
+
+        let mut buf = String::new();
+        File::from(pipe_rx).read_to_string(&mut buf)?;
+
+        pretty_assertions::assert_eq!(buf, "done\n");
+        Ok(())
+    }
+}

--- a/mm-server/src/compositor/child/container/ipc.rs
+++ b/mm-server/src/compositor/child/container/ipc.rs
@@ -1,0 +1,111 @@
+// Copyright 2024 Colin Marc <hi@colinmarc.com>
+//
+// SPDX-License-Identifier: BUSL-1.1
+
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
+use std::{io, time};
+
+use rustix::event::{eventfd, poll, EventfdFlags, PollFd, PollFlags};
+use rustix::io::{read, write, Errno};
+
+/// An IPC barrier using eventfd(2).
+pub struct EventfdBarrier {
+    a: OwnedFd,
+    b: OwnedFd,
+    other: bool,
+}
+
+impl EventfdBarrier {
+    pub fn new() -> io::Result<(Self, Self)> {
+        let a = eventfd(0, EventfdFlags::NONBLOCK)?;
+        let b = eventfd(0, EventfdFlags::NONBLOCK)?;
+
+        let a2 = a.try_clone()?;
+        let b2 = b.try_clone()?;
+
+        Ok((
+            Self { a, b, other: false },
+            Self {
+                a: a2,
+                b: b2,
+                other: true,
+            },
+        ))
+    }
+
+    // Waits at the barrier, timing out after the given duration.
+    pub fn sync(&self, timeout: time::Duration) -> rustix::io::Result<()> {
+        if self.other {
+            wait_eventfd(&self.a, timeout)?;
+            signal_eventfd(&self.b)?;
+        } else {
+            signal_eventfd(&self.a)?;
+            wait_eventfd(&self.b, timeout)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Creates an IPC channel for sending a file descriptor.
+pub fn fd_oneshot() -> io::Result<(FdSender, FdReceiver)> {
+    let (sender, receiver) = uds::UnixSeqpacketConn::pair()?;
+    Ok((FdSender(sender), FdReceiver(receiver)))
+}
+
+pub struct FdSender(uds::UnixSeqpacketConn);
+
+impl FdSender {
+    pub fn send_timeout(self, fd: OwnedFd, timeout: time::Duration) -> io::Result<()> {
+        self.0.set_write_timeout(Some(timeout))?;
+
+        let raw_fd = fd.as_raw_fd();
+        self.0.send_fds(&[], &[raw_fd])?;
+
+        // The FD gets dropped here, along with our end of the connection.
+        Ok(())
+    }
+}
+
+pub struct FdReceiver(uds::UnixSeqpacketConn);
+
+impl FdReceiver {
+    pub fn recv_timeout(self, timeout: time::Duration) -> io::Result<OwnedFd> {
+        self.0.set_read_timeout(Some(timeout))?;
+
+        let mut fds = [-1];
+
+        self.0.recv_fds(&mut [], &mut fds)?;
+        if fds[0] <= 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected message received",
+            ));
+        }
+
+        let fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        Ok(fd)
+    }
+}
+
+fn signal_eventfd(fd: impl AsFd) -> rustix::io::Result<()> {
+    loop {
+        match write(&fd, &1_u64.to_ne_bytes()).map(|_| ()) {
+            Err(Errno::INTR) => continue,
+            v => return v,
+        }
+    }
+}
+
+fn wait_eventfd(fd: impl AsFd, timeout: time::Duration) -> rustix::io::Result<()> {
+    let mut pollfd = [PollFd::new(&fd, PollFlags::IN)];
+    let mut buf = [0; 8];
+    loop {
+        match poll(&mut pollfd, timeout.as_millis() as _) {
+            Ok(0) => return Err(Errno::TIMEDOUT),
+            Ok(_) => return read(fd, &mut buf).map(|_| ()),
+            Err(Errno::INTR) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}

--- a/mm-server/src/compositor/control.rs
+++ b/mm-server/src/compositor/control.rs
@@ -7,6 +7,7 @@ use crossbeam_channel::Sender;
 use crate::{
     codec::{AudioCodec, VideoCodec},
     color::VideoProfile,
+    compositor::ButtonState,
     pixel_scale::PixelScale,
 };
 
@@ -47,7 +48,7 @@ pub enum ControlMessage {
     Detach(u64),
     UpdateDisplayParams(DisplayParams),
     KeyboardInput {
-        evdev_scancode: u32,
+        key_code: u32,
         state: super::KeyState,
         char: Option<char>,
     },
@@ -59,10 +60,27 @@ pub enum ControlMessage {
         x: f64,
         y: f64,
         button_code: u32,
-        state: super::ButtonState,
+        state: ButtonState,
     },
     PointerAxis(f64, f64),
     PointerAxisDiscrete(f64, f64),
+    GamepadAvailable(u64),
+    GamepadUnavailable(u64),
+    GamepadAxis {
+        id: u64,
+        axis_code: u32,
+        value: f64,
+    },
+    GamepadTrigger {
+        id: u64,
+        trigger_code: u32,
+        value: f64,
+    },
+    GamepadInput {
+        id: u64,
+        button_code: u32,
+        state: ButtonState,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/mm-server/src/compositor/input.rs
+++ b/mm-server/src/compositor/input.rs
@@ -1,0 +1,307 @@
+// Copyright 2024 Colin Marc <hi@colinmarc.com>
+//
+// SPDX-License-Identifier: BUSL-1.1
+
+use std::{
+    io::Cursor,
+    sync::{Arc, Mutex},
+    time,
+};
+
+use fuser as fuse;
+use murmur3::murmur3_32 as murmur3;
+use southpaw::{
+    sys::{EV_ABS, EV_KEY},
+    AbsAxis, AbsInfo, InputEvent, KeyCode, Scancode,
+};
+use tracing::{debug, error};
+
+use crate::compositor::Container;
+
+mod udevfs;
+use udevfs::*;
+
+/// A simulated gamepad layout.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum GamepadLayout {
+    #[default]
+    GenericDualStick,
+}
+
+/// Manages input devices (mostly gamepads) n a container using a variety of
+/// well-intentioned but horrible hacks.
+pub struct InputDeviceManager {
+    southpaw: southpaw::DeviceTree,
+    state: Arc<Mutex<InputManagerState>>,
+}
+
+struct DeviceState {
+    id: u64,
+    short_id: u32, // Used by udevfs.
+    counter: u16,
+    plugged: time::SystemTime,
+    devname: String,
+}
+
+#[derive(Default)]
+struct InputManagerState {
+    counter: u16,
+    devices: Vec<DeviceState>,
+}
+
+impl InputManagerState {
+    fn find_device(&self, short_id: u32) -> Option<&DeviceState> {
+        self.devices.iter().find(|dev| dev.short_id == short_id)
+    }
+}
+
+/// A handle for a plugged gamepad.
+pub struct GamepadHandle {
+    device: southpaw::Device,
+    ev_buffer: Vec<southpaw::InputEvent>,
+    pub permanent: bool,
+}
+impl GamepadHandle {
+    pub(crate) fn axis(&mut self, axis_code: u32, value: f64) {
+        let value = value.clamp(-1.0, 1.0) * 128.0 + 128.0;
+        self.ev_buffer.push(InputEvent::new(
+            EV_ABS,
+            axis_code as u16,
+            value.floor() as i32,
+        ));
+    }
+
+    pub(crate) fn trigger(&mut self, trigger_code: u32, value: f64) {
+        // todo!()
+    }
+
+    pub(crate) fn input(&mut self, button_code: u32, state: super::ButtonState) {
+        // TODO: the DualSense sends D-pad buttons as ABS_HAT0{X,Y}.
+
+        let value = match state {
+            super::ButtonState::Pressed => 1,
+            super::ButtonState::Released => 0,
+        };
+
+        self.ev_buffer
+            .push(InputEvent::new(EV_KEY, button_code as u16, value));
+    }
+
+    pub(crate) fn frame(&mut self) {
+        if let Err(err) = self.device.publish_packet(&self.ev_buffer) {
+            error!(?err, "failed to publish event packet to device");
+        }
+
+        self.ev_buffer.clear();
+    }
+}
+
+impl InputDeviceManager {
+    pub fn new(container: &mut Container) -> anyhow::Result<Self> {
+        let state = Arc::new(Mutex::new(InputManagerState::default()));
+
+        let udevfs_path = container.intern_run_path().join(".udevfs");
+        let southpaw_path = container.intern_run_path().join(".southpaw");
+
+        let udevfs = UdevFs::new(state.clone());
+        let udevfs_path_clone = udevfs_path.clone();
+
+        let southpaw = southpaw::DeviceTree::new();
+        let southpaw_clone = southpaw.clone();
+        let southpaw_path_clone = southpaw_path.clone();
+
+        container.setup_hook(move |c| {
+            let mode = 0o755 | rustix::fs::FileType::Directory.as_raw_mode();
+
+            let device_fd = c.fuse_mount(udevfs_path_clone, "udevfs", mode)?;
+            let mut session = fuse::Session::from_fd(device_fd, udevfs, fuse::SessionACL::Owner);
+            std::thread::spawn(move || session.run());
+
+            let device_fd = c.fuse_mount(southpaw_path_clone, "southpaw", mode)?;
+            southpaw_clone.wrap_fd(device_fd);
+
+            Ok(())
+        });
+
+        container.internal_bind_mount(
+            udevfs_path.join("sys/devices/virtual/input"),
+            "/sys/devices/virtual/input",
+        );
+        container.internal_bind_mount(udevfs_path.join("sys/class/input"), "/sys/class/input");
+        container.internal_bind_mount(udevfs_path.join("run/udev"), "/run/udev");
+        container.internal_bind_mount(southpaw_path, "/dev/input");
+
+        // Without this, udev refuses to accept our FUSE filesystem.
+        container.set_env("SYSTEMD_DEVICE_VERIFY_SYSFS", "false");
+
+        Ok(Self { state, southpaw })
+    }
+
+    pub fn plug_gamepad(
+        &mut self,
+        id: u64,
+        _layout: GamepadLayout,
+        permanent: bool,
+    ) -> anyhow::Result<GamepadHandle> {
+        debug!(id, ?_layout, "gamepad plugged");
+
+        let mut guard = self.state.lock().unwrap();
+
+        guard.counter += 1;
+        let counter = guard.counter;
+        let devname = format!("event{counter}");
+
+        let xy_absinfo = AbsInfo {
+            value: 128,
+            minimum: 0,
+            maximum: 255,
+            ..Default::default()
+        };
+
+        let trigger_absinfo = AbsInfo {
+            value: 0,
+            minimum: 0,
+            maximum: 255,
+            ..Default::default()
+        };
+
+        let dpad_absinfo = AbsInfo {
+            value: 0,
+            minimum: -1,
+            maximum: 1,
+            ..Default::default()
+        };
+
+        let device = southpaw::Device::builder()
+            .name("Magic Mirror Emulated DualSense Controller")
+            .id(southpaw::BusType::Usb, 0x54c, 0xce5, 0x8111)
+            .supported_key_codes([
+                KeyCode::BtnSouth,
+                KeyCode::BtnNorth,
+                KeyCode::BtnEast,
+                KeyCode::BtnWest,
+                KeyCode::BtnTl,
+                KeyCode::BtnTr,
+                KeyCode::BtnTl2,
+                KeyCode::BtnTr2,
+                KeyCode::BtnSelect,
+                KeyCode::BtnStart,
+                KeyCode::BtnMode,
+                KeyCode::BtnThumbl,
+                KeyCode::BtnThumbr,
+                // Scancode::AbsoluteAxis(AbsAxis::X),
+                // Scancode::AbsoluteAxis(AbsAxis::Y),
+                // Scancode::AbsoluteAxis(AbsAxis::RX),
+                // Scancode::AbsoluteAxis(AbsAxis::RY),
+                // Scancode::AbsoluteAxis(AbsAxis::Z),
+                // Scancode::AbsoluteAxis(AbsAxis::RZ),
+                // Scancode::AbsoluteAxis(AbsAxis::HAT0X),
+                // Scancode::AbsoluteAxis(AbsAxis::HAT0Y),
+            ])
+            .supported_absolute_axis(AbsAxis::X, xy_absinfo)
+            .supported_absolute_axis(AbsAxis::Y, xy_absinfo)
+            .supported_absolute_axis(AbsAxis::RX, xy_absinfo)
+            .supported_absolute_axis(AbsAxis::RY, xy_absinfo)
+            .add_to_tree(&mut self.southpaw, &devname)?;
+
+        let short_id = murmur3(&mut Cursor::new(id.to_ne_bytes()), 0).unwrap();
+        guard.devices.push(DeviceState {
+            id,
+            short_id,
+            counter,
+            devname,
+            plugged: time::SystemTime::now(),
+        });
+
+        Ok(GamepadHandle {
+            device,
+            ev_buffer: Vec::new(),
+            permanent,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, fs::File, io::Read as _};
+
+    use rustix::pipe::{pipe_with, PipeFlags};
+
+    use crate::{
+        compositor::Container,
+        config::{AppConfig, HomeIsolationMode},
+    };
+
+    use super::{GamepadLayout, InputDeviceManager};
+
+    fn run_in_container_with_gamepads<T>(cmd: impl AsRef<[T]>) -> anyhow::Result<String>
+    where
+        T: AsRef<str>,
+    {
+        let command = cmd
+            .as_ref()
+            .iter()
+            .map(|s| s.as_ref().to_owned().into())
+            .collect();
+
+        let app_config = AppConfig {
+            description: None,
+            command,
+            env: HashMap::new(),
+            xwayland: false,
+            force_1x_scale: false,
+            home_isolation_mode: HomeIsolationMode::Unisolated,
+        };
+
+        let mut container = Container::new(app_config)?;
+        let (pipe_rx, pipe_tx) = pipe_with(PipeFlags::CLOEXEC)?;
+        container.set_stdout(pipe_tx)?;
+
+        container.set_env("SYSTEMD_LOG_LEVEL", "debug");
+        let mut input_manager = InputDeviceManager::new(&mut container)?;
+
+        let mut child = container.spawn()?;
+
+        let _ = input_manager.plug_gamepad(1234, GamepadLayout::GenericDualStick, false)?;
+        let _ = input_manager.plug_gamepad(5678, GamepadLayout::GenericDualStick, false)?;
+        let _ = child.wait();
+
+        let mut buf = String::new();
+        File::from(pipe_rx).read_to_string(&mut buf)?;
+
+        Ok(buf)
+    }
+
+    #[test_log::test]
+    fn list_devices_subsystem() -> anyhow::Result<()> {
+        let output = run_in_container_with_gamepads([
+            "udevadm",
+            "--debug",
+            "trigger",
+            "--dry-run",
+            "--verbose",
+            "--subsystem-match",
+            "input",
+        ])?;
+
+        pretty_assertions::assert_eq!(
+            output,
+            "/sys/devices/virtual/input/event1\n/sys/devices/virtual/input/event2\n"
+        );
+        Ok(())
+    }
+
+    #[test_log::test]
+    fn gilrs_gamepad_info() -> anyhow::Result<()> {
+        let output = run_in_container_with_gamepads([
+            "/home/colinmarc/src/gilrs/target/debug/examples/gamepad_info",
+        ])?;
+
+        pretty_assertions::assert_eq!(
+            output,
+            "/sys/devices/virtual/input/event1\n/sys/devices/virtual/input/event2\n"
+        );
+
+        Ok(())
+    }
+}

--- a/mm-server/src/compositor/input/udevfs.rs
+++ b/mm-server/src/compositor/input/udevfs.rs
@@ -1,0 +1,563 @@
+// Copyright 2024 Colin Marc <hi@colinmarc.com>
+//
+// SPDX-License-Identifier: BUSL-1.1
+
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    str::FromStr as _,
+    sync::{Arc, Mutex},
+    time,
+};
+
+use fuser as fuse;
+use libc::EBADF;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use tracing::{debug, warn};
+
+use super::DeviceState;
+
+const ENOENT: i32 = rustix::io::Errno::NOENT.raw_os_error();
+
+const STATIC_DIRS: &[&str] = &[
+    "sys",
+    "sys/devices",
+    "sys/devices/virtual",
+    "sys/devices/virtual/input",
+    "sys/class",
+    "sys/class/input",
+    "run",
+    "run/udev",
+    "run/udev/data",
+];
+
+// Must match the indexes above. Verified with a test.
+const SYS_DEVICES_VIRTUAL_INPUT: u64 = static_ino(3);
+const SYS_CLASS_INPUT: u64 = static_ino(5);
+const UDEV_DATA: u64 = static_ino(8);
+
+const UDEV_INPUT_DATA: &str = r#"E:ID_INPUT=1
+E:ID_INPUT_JOYSTICK=1
+E:ID_BUS=usb
+G:seat
+G:uaccess
+Q:seat
+Q:uaccess
+V:1
+"#;
+
+const STATIC_TTL: time::Duration = time::Duration::MAX;
+const SHORT_TTL: time::Duration = time::Duration::ZERO;
+
+const fn static_ino(idx: usize) -> u64 {
+    idx as u64 + fuse::FUSE_ROOT_ID + 1
+}
+
+fn static_path(ino: u64) -> Option<&'static str> {
+    let idx = ino - fuse::FUSE_ROOT_ID - 1;
+    STATIC_DIRS.get(idx as usize).copied()
+}
+
+#[derive(Clone)]
+struct StaticEntry {
+    parent_ino: u64,
+    child_inos: Vec<u64>,
+    relpath: PathBuf,
+    attr: fuse::FileAttr,
+}
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+enum InodeType {
+    /// The directory in /sys/devices/virtual/input.
+    InputDir = 0,
+    /// The symlink in /sys/class/input.
+    InputSymlink = 1,
+    /// A file containing device info, at /sys/devices/virtual/input/{dev}/uevent.
+    Uevent = 2,
+    /// A symlink back to /sys/class/input.
+    SubsystemSymlink = 3,
+    /// The data file in /run/udev/data.
+    DataFile = 4,
+}
+
+/// We use the following encoding for inodes, to make lookup easy:
+///  - The first 32 bytes are the short ID of the device.
+///  - The last 32 bytes are the inode type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DeviceInode {
+    short_id: u32,
+    inode_type: InodeType,
+}
+
+impl DeviceInode {
+    fn make(short_id: u32, inode_type: InodeType) -> u64 {
+        Self {
+            short_id,
+            inode_type,
+        }
+        .into()
+    }
+}
+
+impl From<DeviceInode> for u64 {
+    fn from(value: DeviceInode) -> Self {
+        let res = (value.short_id as u64) << 32;
+        res | u32::from(value.inode_type) as u64
+    }
+}
+
+impl TryFrom<u64> for DeviceInode {
+    type Error = <InodeType as TryFromPrimitive>::Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        let short_id = (value >> 32) as u32;
+        let ty = value as u32;
+        ty.try_into().map(|inode_type| DeviceInode {
+            short_id,
+            inode_type,
+        })
+    }
+}
+
+/// A FUSE filesystem designed to fool libudev. All incoming paths are intended
+/// to be absolute. The following paths are emulated:
+///   - /sys/devices/virtual/input: contains folders for each virtual input
+///     device.
+///   - /sys/class/input: contains symlinks to the above device entries.
+///   - /run/udev/data: contains "c{major}:{minor}" files with metadata on each
+///     device.
+pub struct UdevFs {
+    state: Arc<Mutex<super::InputManagerState>>,
+    static_inodes: HashMap<u64, StaticEntry>, // Indexed by inode.
+}
+
+impl UdevFs {
+    pub fn new(state: Arc<Mutex<super::InputManagerState>>) -> Self {
+        let ctime = time::SystemTime::now();
+
+        let mut static_inodes: HashMap<u64, StaticEntry> = HashMap::new();
+
+        for (idx, entry) in STATIC_DIRS.iter().enumerate() {
+            let mut relpath = PathBuf::from_str(entry).unwrap();
+            let ino = static_ino(idx);
+
+            // Attempt to find the parent.
+            let mut parent_ino = fuse::FUSE_ROOT_ID;
+            for (prev_idx, prev_p) in STATIC_DIRS[..idx].iter().enumerate().rev() {
+                if let Ok(p) = relpath.strip_prefix(prev_p) {
+                    parent_ino = static_ino(prev_idx);
+                    relpath = p.to_owned();
+                    break;
+                }
+            }
+
+            if let Some(parent) = static_inodes.get_mut(&parent_ino) {
+                parent.child_inos.push(ino);
+            }
+
+            assert_eq!(
+                relpath.components().count(),
+                1,
+                "failed to find parent for {}",
+                relpath.display()
+            );
+            static_inodes.insert(
+                ino,
+                StaticEntry {
+                    parent_ino,
+                    child_inos: Vec::new(),
+                    relpath,
+                    attr: make_dir_attr(ino, ctime),
+                },
+            );
+        }
+
+        Self {
+            state,
+            static_inodes,
+        }
+    }
+}
+
+impl fuse::Filesystem for UdevFs {
+    fn lookup(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        parent: u64,
+        name: &std::ffi::OsStr,
+        reply: fuser::ReplyEntry,
+    ) {
+        let Some(name) = name.to_str() else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        if parent == SYS_DEVICES_VIRTUAL_INPUT {
+            let guard = self.state.lock().unwrap();
+            for dev in &guard.devices {
+                if name == dev.devname {
+                    let ino = DeviceInode::make(dev.short_id, InodeType::InputDir);
+                    reply.entry(&SHORT_TTL, &make_dir_attr(ino, dev.plugged), 0);
+                    return;
+                }
+            }
+        }
+
+        if parent == SYS_CLASS_INPUT {
+            let guard = self.state.lock().unwrap();
+            for dev in &guard.devices {
+                if name == dev.devname {
+                    let ino = DeviceInode::make(dev.short_id, InodeType::InputSymlink);
+                    reply.entry(&SHORT_TTL, &make_symlink_attr(ino, dev.plugged), 0);
+                    return;
+                }
+            }
+        }
+
+        if parent == UDEV_DATA {
+            let guard = self.state.lock().unwrap();
+            for dev in &guard.devices {
+                if name == format!("c13:{}", dev.counter) {
+                    let ino = DeviceInode::make(dev.short_id, InodeType::DataFile);
+                    reply.entry(
+                        &SHORT_TTL,
+                        &make_file_attr(ino, dev.plugged, UDEV_INPUT_DATA.len()),
+                        0,
+                    );
+                    return;
+                }
+            }
+        }
+
+        for entry in self.static_inodes.values() {
+            if entry.parent_ino == parent && name == entry.relpath.as_os_str() {
+                reply.entry(&STATIC_TTL, &entry.attr, 0);
+                return;
+            }
+        }
+
+        let Ok(DeviceInode {
+            short_id,
+            inode_type,
+        }) = parent.try_into()
+        else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let guard = self.state.lock().unwrap();
+        let Some(dev) = guard.find_device(short_id) else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        match (inode_type, name) {
+            (InodeType::InputDir, "uevent") => {
+                let content = make_uevent(dev);
+                let ino = DeviceInode::make(short_id, InodeType::Uevent);
+                reply.entry(
+                    &SHORT_TTL,
+                    &make_file_attr(ino, dev.plugged, content.len()),
+                    0,
+                );
+
+                return;
+            }
+            (InodeType::InputDir, "subsystem") => {
+                let ino = DeviceInode::make(short_id, InodeType::SubsystemSymlink);
+                reply.entry(&SHORT_TTL, &make_symlink_attr(ino, dev.plugged), 0);
+                return;
+            }
+            (InodeType::InputDir, "dev") => (), // TODO
+            _ => (),
+        }
+
+        warn!(parent = static_path(parent), name, "udevfs lookup failed");
+        reply.error(ENOENT);
+    }
+
+    fn getattr(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        ino: u64,
+        _fh: Option<u64>,
+        reply: fuser::ReplyAttr,
+    ) {
+        if let Some(entry) = self.static_inodes.get(&ino) {
+            reply.attr(&STATIC_TTL, &entry.attr);
+            return;
+        }
+
+        let Ok(DeviceInode {
+            short_id,
+            inode_type,
+        }) = ino.try_into()
+        else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let guard = self.state.lock().unwrap();
+        let Some(dev) = guard.find_device(short_id) else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let attr = match inode_type {
+            InodeType::InputDir => make_dir_attr(ino, dev.plugged),
+            InodeType::InputSymlink => make_symlink_attr(ino, dev.plugged),
+            InodeType::SubsystemSymlink => make_symlink_attr(ino, dev.plugged),
+            InodeType::Uevent => {
+                let contents = make_uevent(dev);
+                make_file_attr(ino, dev.plugged, contents.len())
+            }
+            InodeType::DataFile => make_file_attr(ino, dev.plugged, UDEV_INPUT_DATA.len()),
+        };
+
+        reply.attr(&SHORT_TTL, &attr);
+    }
+
+    fn readlink(&mut self, _req: &fuser::Request<'_>, ino: u64, reply: fuser::ReplyData) {
+        let Ok(DeviceInode {
+            short_id,
+            inode_type,
+        }) = ino.try_into()
+        else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let guard = self.state.lock().unwrap();
+        let Some(dev) = guard.find_device(short_id) else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        match inode_type {
+            InodeType::InputSymlink => {
+                let dst = format!("/sys/devices/virtual/input/{}", dev.devname);
+                reply.data(dst.as_bytes());
+            }
+            InodeType::SubsystemSymlink => {
+                reply.data(b"/sys/class/input");
+            }
+            _ => reply.error(ENOENT),
+        }
+    }
+
+    fn read(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        ino: u64,
+        _fh: u64,
+        _offset: i64,
+        _size: u32,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        reply: fuser::ReplyData,
+    ) {
+        if self.static_inodes.contains_key(&ino) {
+            return reply.error(EBADF);
+        }
+
+        let Ok(DeviceInode {
+            short_id,
+            inode_type,
+        }) = ino.try_into()
+        else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let guard = self.state.lock().unwrap();
+        let Some(dev) = guard.find_device(short_id) else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        match inode_type {
+            InodeType::Uevent => {
+                let contents = make_uevent(dev);
+                reply.data(contents.as_bytes())
+            }
+            InodeType::DataFile => reply.data(UDEV_INPUT_DATA.as_bytes()),
+            _ => reply.error(ENOENT),
+        };
+    }
+
+    fn readdir(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        mut reply: fuser::ReplyDirectory,
+    ) {
+        if ino == SYS_DEVICES_VIRTUAL_INPUT {
+            todo!() // It doesn't seem like udev ever does this.
+        }
+
+        if ino == SYS_CLASS_INPUT {
+            let guard = self.state.lock().unwrap();
+
+            for (
+                idx,
+                DeviceState {
+                    short_id, devname, ..
+                },
+            ) in guard.devices.iter().skip(offset as usize).enumerate()
+            {
+                debug!(devname, "udev is enumerating device");
+
+                if reply.add(
+                    DeviceInode::make(*short_id, InodeType::InputSymlink),
+                    (idx as i64) + 1,
+                    fuse::FileType::Symlink,
+                    devname,
+                ) {
+                    break;
+                }
+            }
+
+            reply.ok();
+            return;
+        }
+
+        if let Some(entry) = self.static_inodes.get(&ino).cloned() {
+            for child_ino in entry.child_inos {
+                let child_entry = self.static_inodes.get(&child_ino).unwrap();
+                if reply.add(
+                    child_ino,
+                    0,
+                    fuse::FileType::Directory,
+                    child_entry.relpath.file_name().unwrap(),
+                ) {
+                    break;
+                };
+            }
+
+            reply.ok();
+            return;
+        }
+
+        reply.error(ENOENT);
+    }
+
+    fn access(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        _ino: u64,
+        _mask: i32,
+        reply: fuser::ReplyEmpty,
+    ) {
+        reply.ok()
+    }
+
+    fn release(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        _ino: u64,
+        _fh: u64,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        _flush: bool,
+        reply: fuser::ReplyEmpty,
+    ) {
+        reply.ok()
+    }
+}
+
+fn make_uevent(dev: &DeviceState) -> String {
+    format!(
+        "MAJOR=13\nMINOR={}\nDEVNAME=input/{}\n",
+        dev.counter, dev.devname
+    )
+}
+
+const fn make_file_attr(ino: u64, t: time::SystemTime, len: usize) -> fuse::FileAttr {
+    fuser::FileAttr {
+        ino,
+        size: len as u64,
+        blocks: 0,
+        atime: t,
+        mtime: t,
+        ctime: t,
+        crtime: time::SystemTime::UNIX_EPOCH,
+        kind: fuse::FileType::RegularFile,
+        perm: 0o644,
+        nlink: 1,
+        uid: 0,
+        gid: 0,
+        rdev: 0,
+        blksize: 512,
+        flags: 0,
+    }
+}
+
+const fn make_dir_attr(ino: u64, t: time::SystemTime) -> fuse::FileAttr {
+    fuser::FileAttr {
+        ino,
+        size: 0,
+        blocks: 0,
+        atime: t,
+        mtime: t,
+        ctime: t,
+        crtime: time::SystemTime::UNIX_EPOCH,
+        kind: fuse::FileType::Directory,
+        perm: 0o777,
+        nlink: 1,
+        uid: 0,
+        gid: 0,
+        rdev: 0,
+        blksize: 512,
+        flags: 0,
+    }
+}
+fn make_symlink_attr(ino: u64, t: time::SystemTime) -> fuse::FileAttr {
+    fuser::FileAttr {
+        ino,
+        size: 0,
+        blocks: 0,
+        atime: t,
+        mtime: t,
+        ctime: t,
+        crtime: time::SystemTime::UNIX_EPOCH,
+        kind: fuse::FileType::Symlink,
+        perm: 0o777,
+        nlink: 1,
+        uid: 0,
+        gid: 0,
+        rdev: 0,
+        blksize: 512,
+        flags: 0,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn static_inodes_correct() {
+        assert_eq!(
+            static_path(SYS_DEVICES_VIRTUAL_INPUT),
+            Some("sys/devices/virtual/input"),
+        );
+        assert_eq!(static_path(SYS_CLASS_INPUT), Some("sys/class/input"));
+        assert_eq!(static_path(UDEV_DATA), Some("run/udev/data"));
+    }
+
+    #[test]
+    fn inode_serde() {
+        let inode = DeviceInode {
+            short_id: 12345,
+            inode_type: InodeType::InputSymlink,
+        };
+
+        let v: u64 = inode.into();
+        assert_eq!(v, 53021371269121);
+
+        assert_eq!(DeviceInode::try_from(v), Ok(inode));
+    }
+}

--- a/mm-server/src/main.rs
+++ b/mm-server/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
     let mut cfg = config::Config::new(args.config.as_ref(), &args.include_apps)
         .context("failed to read config")?;
 
-    preflight_checks()?;
+    preflight_checks(&cfg)?;
 
     // Override with command line flags.
     cfg.bug_report_dir = bug_report_dir.clone();
@@ -182,7 +182,7 @@ fn init_logging(bug_report_dir: Option<impl AsRef<Path>>) -> Result<()> {
     Ok(())
 }
 
-fn preflight_checks() -> anyhow::Result<()> {
+fn preflight_checks(cfg: &config::Config) -> anyhow::Result<()> {
     match linux_version() {
         Some((major, minor)) if major < 6 => {
             bail!("kernel version {major}.{minor} is too low; 6.x required");
@@ -190,6 +190,11 @@ fn preflight_checks() -> anyhow::Result<()> {
         None => warn!("unable to determine linux kernel version!"),
         _ => (),
     }
+
+    std::fs::create_dir_all(&cfg.data_home).context(format!(
+        "failed to initialize data_home ({})",
+        cfg.data_home.display(),
+    ))?;
 
     Ok(())
 }

--- a/mm-server/src/server/handlers.rs
+++ b/mm-server/src/server/handlers.rs
@@ -120,6 +120,12 @@ fn launch_session(
         }
     };
 
+    for gamepad in msg.permanent_gamepads.clone() {
+        if let Err(ve) = validate_gamepad(Some(gamepad)) {
+            send_validation_error(response, ve, false);
+        }
+    }
+
     let bug_report_dir = guard.cfg.bug_report_dir.clone();
     drop(guard);
 
@@ -128,6 +134,7 @@ fn launch_session(
         &msg.application_name,
         &application_config,
         display_params,
+        msg.permanent_gamepads,
         bug_report_dir,
     ) {
         Ok(s) => s,
@@ -163,7 +170,7 @@ fn list_sessions(state: SharedState, response: &WakingSender<protocol::MessageTy
             session_start: Some(s.started.into()),
             display_params: Some(s.display_params.into()),
             supported_streaming_resolutions: generate_streaming_res(&s.display_params),
-            permanent_gamepads: Vec::new(),
+            permanent_gamepads: s.permanent_gamepads.clone(),
         })
         .collect();
 
@@ -296,7 +303,6 @@ fn attach(
                     ErrorCode::ErrorServer,
                     Some("failed to attach to session".to_string()),
                 );
-
                 return;
             }
         }
@@ -402,7 +408,7 @@ fn attach(
                                     Ok(KeyState::Repeat) => compositor::KeyState::Repeat,
                                 };
 
-                                let evdev_scancode = match protocol::keyboard_input::Key::try_from(ev.key).map(key_to_evdev) {
+                                let key_code = match protocol::keyboard_input::Key::try_from(ev.key).map(key_to_evdev) {
                                     Ok(Some(scancode)) => scancode,
                                     _ => {
                                         send_err(outgoing, ErrorCode::ErrorProtocol, Some("invalid key".to_string()));
@@ -421,10 +427,10 @@ fn attach(
                                     }
                                 };
 
-                                trace!(evdev_scancode, ?state, ?ch, "translated keyboard event");
+                                trace!(key_code, ?state, ?ch, "translated keyboard event");
 
                                 handle.control.send(ControlMessage::KeyboardInput{
-                                    evdev_scancode,
+                                    key_code,
                                     state,
                                     char: ch,
                                 }).ok();
@@ -493,11 +499,70 @@ fn attach(
                                     }
                                 }
                             }
-                            // Gamepads are not yet supported.
-                            protocol::MessageType::GamepadAvailable(ev) => debug!("{:?}", ev),
-                            protocol::MessageType::GamepadUnavailable(ev) => debug!("{:?}", ev),
-                            protocol::MessageType::GamepadMotion(ev) => debug!("{:?}", ev),
-                            protocol::MessageType::GamepadInput(ev) => debug!("{:?}", ev),
+                            protocol::MessageType::GamepadAvailable(ev) => {
+                                let (id, _layout) = match validate_gamepad(ev.gamepad) {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        send_validation_error(outgoing, e, true);
+                                        return;
+                                    }
+                                };
+
+                                handle.control.send(ControlMessage::GamepadAvailable(id)).ok();
+                            }
+                            protocol::MessageType::GamepadUnavailable(ev) => {
+                                handle.control.send(ControlMessage::GamepadUnavailable(ev.id)).ok();
+                            }
+                            protocol::MessageType::GamepadMotion(ev) => {
+                                let (scancode, is_trigger) = match protocol::gamepad_motion::GamepadAxis::try_from(ev.axis).ok().and_then(axis_to_evdev) {
+                                    Some(v) => v,
+                                    _ => {
+                                        send_err(outgoing, ErrorCode::ErrorProtocol, Some("invalid gamepad axis".to_string()));
+                                        return;
+                                    }
+                                };
+
+                                let cm = if is_trigger {
+                                    ControlMessage::GamepadTrigger {
+                                        id: ev.gamepad_id,
+                                        trigger_code: scancode,
+                                        value: ev.value,
+                                    }
+                                } else {
+                                    ControlMessage::GamepadAxis {
+                                        id: ev.gamepad_id,
+                                        axis_code: scancode,
+                                        value: ev.value,
+                                    }
+                                };
+
+                                handle.control.send(cm).ok();
+                            },
+                            protocol::MessageType::GamepadInput(ev) => {
+                                use protocol::gamepad_input::{GamepadButton, GamepadButtonState};
+                                let state = match ev.state.try_into() {
+                                    Ok(GamepadButtonState::Unknown) | Err(_) => {
+                                        send_err(outgoing, ErrorCode::ErrorProtocol, Some("invalid gamepad button state".to_string()));
+                                        return;
+                                    }
+                                    Ok(GamepadButtonState::Pressed) => compositor::ButtonState::Pressed,
+                                    Ok(GamepadButtonState::Released) => compositor::ButtonState::Released,
+                                };
+
+                                let scancode = match GamepadButton::try_from(ev.button).ok().and_then(gamepad_button_to_evdev) {
+                                    Some(v) => v,
+                                    _ => {
+                                        send_err(outgoing, ErrorCode::ErrorProtocol, Some("invalid gamepad button".to_string()));
+                                        return;
+                                    }
+                                };
+
+                                handle.control.send(ControlMessage::GamepadInput {
+                                    id: ev.gamepad_id,
+                                    button_code: scancode,
+                                    state,
+                                }).ok();
+                            }
                             protocol::MessageType::Error(ev) => {
                                 error!("received error from client: {}: {}", ev.err_code().as_str_name(), ev.error_text);
                             }
@@ -825,6 +890,50 @@ fn key_to_evdev(key: protocol::keyboard_input::Key) -> Option<u32> {
         | Key::NumpadMemoryStore
         | Key::NumpadMemorySubtract => None,
         Key::Unknown => None,
+    }
+}
+
+fn axis_to_evdev(axis: protocol::gamepad_motion::GamepadAxis) -> Option<(u32, bool)> {
+    use protocol::gamepad_motion::GamepadAxis;
+    match axis {
+        GamepadAxis::LeftX => Some((0x00, false)),       // ABS_X
+        GamepadAxis::LeftY => Some((0x01, false)),       // ABS_Y
+        GamepadAxis::RightX => Some((0x03, false)),      // ABS_RX
+        GamepadAxis::RightY => Some((0x04, false)),      // ABS_RY,
+        GamepadAxis::LeftTrigger => Some((0x02, true)),  // ABS_Z
+        GamepadAxis::RightTrigger => Some((0x05, true)), // ABS_RZ
+        GamepadAxis::Unknown => None,
+    }
+}
+
+fn gamepad_button_to_evdev(button: protocol::gamepad_input::GamepadButton) -> Option<u32> {
+    use protocol::gamepad_input::GamepadButton;
+
+    // TODO: My Dualsense actually reports Dpad events as an axis (ABS_HAT0X).
+    // Otherwise, this simulates a Sony controller.
+
+    match button {
+        GamepadButton::DpadLeft => Some(0x222),      // BTN_DPAD_LEFT
+        GamepadButton::DpadRight => Some(0x223),     // BTN_DPAD_RIGHT
+        GamepadButton::DpadUp => Some(0x220),        // BTN_DPAD_UP
+        GamepadButton::DpadDown => Some(0x221),      // BTN_DPAD_DOWN
+        GamepadButton::South => Some(0x130),         // BTN_SOUTH
+        GamepadButton::East => Some(0x131),          // BTN_EAST
+        GamepadButton::North => Some(0x133),         // BTN_NORTH
+        GamepadButton::West => Some(0x134),          // BTN_WEST
+        GamepadButton::C => Some(0x132),             // BTN_C
+        GamepadButton::Z => Some(0x135),             // BTN_Z
+        GamepadButton::ShoulderLeft => Some(0x136),  // BTN_TL
+        GamepadButton::ShoulderRight => Some(0x137), // BTN_TR
+        GamepadButton::JoystickLeft => Some(0x13d),  // BTN_THUMBL
+        GamepadButton::JoystickRight => Some(0x13e), // BTN_THUMBR
+        GamepadButton::Start => Some(0x13b),         // BTN_START
+        GamepadButton::Select => Some(0x13a),        // BTN_SELECT
+        GamepadButton::Logo => Some(0x13c),          // BTN_MODE
+        GamepadButton::Share => None,                // TODO I'm not sure what code to use.
+        GamepadButton::TriggerLeft => Some(0x138),   // BTN_TL2
+        GamepadButton::TriggerRight => Some(0x139),  // BTN_TL3
+        GamepadButton::Unknown => None,
     }
 }
 

--- a/mm-server/src/server/handlers.rs
+++ b/mm-server/src/server/handlers.rs
@@ -296,6 +296,7 @@ fn attach(
                     ErrorCode::ErrorServer,
                     Some("failed to attach to session".to_string()),
                 );
+
                 return;
             }
         }

--- a/mm-server/src/server/handlers.rs
+++ b/mm-server/src/server/handlers.rs
@@ -909,9 +909,6 @@ fn axis_to_evdev(axis: protocol::gamepad_motion::GamepadAxis) -> Option<(u32, bo
 fn gamepad_button_to_evdev(button: protocol::gamepad_input::GamepadButton) -> Option<u32> {
     use protocol::gamepad_input::GamepadButton;
 
-    // TODO: My Dualsense actually reports Dpad events as an axis (ABS_HAT0X).
-    // Otherwise, this simulates a Sony controller.
-
     match button {
         GamepadButton::DpadLeft => Some(0x222),      // BTN_DPAD_LEFT
         GamepadButton::DpadRight => Some(0x223),     // BTN_DPAD_RIGHT

--- a/mm-server/src/session.rs
+++ b/mm-server/src/session.rs
@@ -85,10 +85,13 @@ impl Session {
             let span = debug_span!("session", session_id = id, app = app_name);
             let _guard = span.enter();
 
-            let mut compositor =
-                Compositor::new(vk_clone, app_cfg, display_params, bug_report_dir_clone)?;
-
-            compositor.run(ready_send)
+            Compositor::run(
+                vk_clone,
+                app_cfg,
+                display_params,
+                bug_report_dir_clone,
+                ready_send,
+            )
         });
 
         info!(session_id = id, application = ?application_name, "launching session");

--- a/mm-server/src/vulkan.rs
+++ b/mm-server/src/vulkan.rs
@@ -921,6 +921,8 @@ pub struct VkHostBuffer {
     vk: Arc<VkContext>,
 }
 
+unsafe impl Send for VkHostBuffer {}
+
 impl VkHostBuffer {
     pub fn new(
         vk: Arc<VkContext>,

--- a/mm-server/src/vulkan/chain.rs
+++ b/mm-server/src/vulkan/chain.rs
@@ -50,6 +50,8 @@ macro_rules! vk_chain {
 
             $vis struct $Chain(std::pin::Pin<Box<[<$Chain Inner>] <'static> >>);
 
+            unsafe impl Send for $Chain {}
+
             #[allow(dead_code)]
             impl $Chain {
                 pub fn new<$lifetime: 'static>($HeadName: $HeadStruct, $($Name: $Struct,)*) -> Self {

--- a/mmserver.default.toml
+++ b/mmserver.default.toml
@@ -24,6 +24,15 @@
 ##
 # include_apps = ["/etc/magic-mirror/apps.d"]
 
+## This determines where the server stores application data, i.e. the $HOME for
+## containerized applications. If not set, then $XDG_DATA_HOME/mmserver is used,
+## or $HOME/.local/share/mmserver if $XDG_DATA_HOME is not set.
+##
+## If you're running magic-mirror as a permanent daemon, you should set this to
+## something like /var/lib/magic-mirror.
+##
+# data_home = /var/lib/magic-mirror
+
 ## ***-----------------***
 ## *** Server Settings ***
 ## ***-----------------***
@@ -90,6 +99,25 @@ max_connections = 4
 ## elements.
 # force_1x_scale = false
 
+## Isolate the home directory. If set, the application will see a clean,
+## sandboxed $HOME (and /home/$(whoami)), rather than the system-wide one.
+## This home directory is saved between runs of the app to
+## `<data_home>/homes/<shared_home_name>`.
+# isolate_home = true
+
+## If `isolate_home` is set to true, this sets a name for the home directory,
+## can be shared between apps. For example, multiple apps with this option set
+## to 'myhome' will all see the same $HOME when they run. By default, this is
+## set to the name of the application.
+# shared_home_name = same as application name
+
+## If `isolate_home` is set to true, this mounts a brand new $HOME (using tmpfs)
+## each time the application is run. If set, `shared_home_name` is ignored.
+##
+## Note that any data saved while the app is running will be irrevocably
+## destroyed when it exits.
+# tmp_home = false
+
 ## ***----------------------***
 ## *** Default App Settings ***
 ## ***----------------------***
@@ -100,3 +128,5 @@ max_connections = 4
 [default_app_settings]
 xwayland = true
 force_1x_scale = false
+isolate_home = true
+tmp_home = false


### PR DESCRIPTION
With this new functionality, we offer some lightweight isolation for apps, on the level of unshare(1). This has a few benefits:

 - We can more easily manage Wayland and XWayland sockets and mount them in a "system global" location.

 - Apps which make a lot of mess, like Steam, have their mess somewhat contained. This mess takes two forms: data stored in the filesystem and daemonized processes. For the former, we offer the option (on by default) to have a per-app permanent HOME separate from the server's $HOME. For the latter, we use a PID namespace, so that when the app is killed, all its children are reaped by the kernel.

 - In the future, this will allow us to virtualize gamepads in a contained way.

 - There is no dependency on a systemwide daemon like docker, or any systemwide tools. Everything is plain syscalls.

This requires some features only available in 5.x kernels, but we already require 6.x for dmabuf/syncobj stuff.

One final note: this is not a security feature. Don't use it to run untrusted code!