### PR TITLE
fix(mmserver): try to avoid binding the system x11 abstract socket

### DIFF
--- a/mm-server/src/session/compositor/xwayland.rs
+++ b/mm-server/src/session/compositor/xwayland.rs
@@ -4,7 +4,7 @@
 
 mod xwm;
 use std::{
-    io::Read as _,
+    io::{self, Read as _},
     os::fd::{AsFd, AsRawFd as _},
     path::{Path, PathBuf},
     sync::Arc,
@@ -22,16 +22,54 @@ use crate::{
 };
 
 pub struct XWayland {
-    pub display_socket: PathBuf,
+    pub display_socket: DisplaySocket,
     pub displayfd_recv: mio::unix::pipe::Receiver,
     pub child: ContainerHandle,
 
+    extern_socket_dir: PathBuf,
     xwm_socket: Option<mio::net::UnixStream>,
 }
 
 // Where the socket gets mounted inside the container.
-const SOCKET_PATH: &str = "/tmp/.X11-unix/X1";
-const DISPLAY: &str = ":1";
+const CONONICAL_DISPLAY_PATH: &str = "/tmp/.X11-unix";
+
+pub struct DisplaySocket(u32);
+
+impl DisplaySocket {
+    fn pick_unused() -> anyhow::Result<Self> {
+        use rustix::net::*;
+
+        // Because we're using a mount namespace, we don't need to worry about
+        // system sockets in /tmp leaking into our container. However, because we
+        // don't use a network namespace, it is possible for system abstract sockets
+        // to be available. We can ensure that isn't the case by attempting to
+        // bind the abstract socket.
+        let mut display = 1;
+        let sock = socket(AddressFamily::UNIX, SocketType::STREAM, None)?;
+
+        loop {
+            let dp = DisplaySocket(display);
+
+            match rustix::net::bind_unix(
+                &sock,
+                // By convention, the name is the same as the path.
+                &SocketAddrUnix::new_abstract_name(dp.inner_path().as_os_str().as_encoded_bytes())?,
+            ) {
+                Ok(()) => return Ok(dp), // Discard the abstract socket.
+                Err(e) if e.kind() == io::ErrorKind::AddrInUse => display += 1,
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    pub fn display(&self) -> String {
+        format!(":{}", self.0)
+    }
+
+    pub fn inner_path(&self) -> PathBuf {
+        Path::new(CONONICAL_DISPLAY_PATH).join(format!("X{}", self.0))
+    }
+}
 
 impl XWayland {
     pub fn spawn(
@@ -46,14 +84,17 @@ impl XWayland {
         // it's ready.
         let (displayfd_send, displayfd_recv) = mio::unix::pipe::new()?;
 
-        // Put the socket in a folder, so we can bind-mount that to
-        // /tmp/.X11-unix inside the container.
-        let socket_path = xdg_runtime_dir
-            .as_ref()
-            .join(Path::new(SOCKET_PATH).strip_prefix("/tmp").unwrap());
-        std::fs::create_dir_all(socket_path.parent().unwrap())?;
+        let display_socket = DisplaySocket::pick_unused()?;
 
-        let socket = mio::net::UnixListener::bind(&socket_path)?;
+        // Put the socket in a folder, so we can bind-mount that to
+        // /tmp/.X11-unix inside the (app) container.
+        let extern_socket_path = xdg_runtime_dir
+            .as_ref()
+            .join(display_socket.inner_path().strip_prefix("/").unwrap());
+        let extern_socket_dir = extern_socket_path.parent().unwrap();
+
+        std::fs::create_dir_all(extern_socket_dir)?;
+        let socket = mio::net::UnixListener::bind(&extern_socket_path)?;
 
         let exe = find_executable_in_path("Xwayland")
             .ok_or(anyhow!("Xwayland not in PATH"))?
@@ -97,7 +138,7 @@ impl XWayland {
         }
 
         let child = container.spawn().context("failed to spawn XWayland")?;
-        debug!(x11_socket = ?socket_path, "spawned Xwayland instance");
+        debug!(x11_socket = ?extern_socket_path, "spawned Xwayland instance");
 
         // Insert the client into the display handle. The order is important
         // here; XWayland never starts up at all unless it can roundtrip with
@@ -108,15 +149,16 @@ impl XWayland {
         )?;
 
         Ok(Self {
-            display_socket: socket_path,
+            display_socket,
             displayfd_recv,
             child,
 
+            extern_socket_dir: extern_socket_dir.to_owned(),
             xwm_socket: Some(xwm_compositor),
         })
     }
 
-    pub fn is_ready(&mut self) -> anyhow::Result<Option<mio::net::UnixStream>> {
+    pub fn poll_ready(&mut self) -> anyhow::Result<Option<mio::net::UnixStream>> {
         if self.xwm_socket.is_none() {
             bail!("XWayland already marked as ready")
         }
@@ -140,16 +182,11 @@ impl XWayland {
     }
 
     pub fn prepare_socket(&self, container: &mut Container) {
-        container.bind_mount(
-            self.display_socket.parent().unwrap(),
-            Path::new(SOCKET_PATH).parent().unwrap(),
-        );
-        container.set_env("DISPLAY", DISPLAY);
+        container.bind_mount(&self.extern_socket_dir, Path::new(CONONICAL_DISPLAY_PATH));
+        container.set_env("DISPLAY", self.display_socket.display());
     }
 }
 
 fn unset_cloexec(socket_fd: impl AsFd) -> Result<(), rustix::io::Errno> {
-    rustix::fs::fcntl_setfd(socket_fd, rustix::fs::FdFlags::empty())?;
-
-    Ok(())
+    rustix::fs::fcntl_setfd(socket_fd, rustix::fs::FdFlags::empty())
 }

--- a/mm-server/src/session/reactor.rs
+++ b/mm-server/src/session/reactor.rs
@@ -254,7 +254,10 @@ impl Reactor {
         if let Some(bug_report_dir) = bug_report_dir.as_ref() {
             let p = bug_report_dir.to_owned();
             let wayland_socket = socket_name.clone();
-            let x11_socket = xwayland.as_ref().map(|x| x.display_socket.clone());
+            let x11_socket = xwayland
+                .as_ref()
+                .map(|x| x.display_socket.inner_path().clone());
+
             std::thread::spawn(move || {
                 save_glxinfo_eglinfo(
                     &p,
@@ -394,7 +397,7 @@ impl Reactor {
                     }
                     XWAYLAND_READY => {
                         let xwayland = self.xwayland.as_mut().unwrap();
-                        if let Some(socket) = xwayland.is_ready()? {
+                        if let Some(socket) = xwayland.poll_ready()? {
                             self.poll
                                 .registry()
                                 .deregister(&mut xwayland.displayfd_recv)?;


### PR DESCRIPTION
A real xserver sometimes creates "abstract" sockets, which transcend the filesystem and can leak into our container (because we don't use a network namespace). That means when running on a system with the system xserver at :1, we would potentially end up colliding with it, and the app would connect to the system xserver instead of xwayland.

Note that we can't just use `DISPLAY=/path/to/internal/socket`, because that's not supported on even some recent libxcb versions.

However, we can avoid this specific situation by just checking whether an abstract socket exists for a given display number, and choosing a higher number if so.