### PR TITLE
fix(docs): specify port in server setup connectivity

### DIFF
--- a/docs/content/setup/server.md
+++ b/docs/content/setup/server.md
@@ -50,7 +50,7 @@ The easiest is to bind to a local IP, or use a VPN like wireguard or tailscale:
 ```toml
 # config.toml
 [server]
-bind = "192.168.1.37"
+bind = "192.168.1.37:9599"
 ```
 
 Or from the command line:


### PR DESCRIPTION
I think that it will be more obvious for user if this configuration will be already defined with default port in docs =)
