### PR TITLE
Use device image format to calculate descriptor allocation size

### DIFF
--- a/mm-client/src/render.rs
+++ b/mm-client/src/render.rs
@@ -316,9 +316,10 @@ impl Renderer {
         };
 
         let descriptor_pool = {
+            let binding_multiplier = get_ycbcr_conversion_properties(self.vk.pdevice, &self.vk.instance, video_texture_format)?.combined_image_sampler_descriptor_count;
             let sampler_size = vk::DescriptorPoolSize::builder()
                 .ty(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-                .descriptor_count(swapchain_images.len() as u32);
+                .descriptor_count(swapchain_images.len() as u32 * binding_multiplier);
 
             let pool_sizes = &[sampler_size.build()];
             let info = vk::DescriptorPoolCreateInfo::builder()

--- a/mm-client/src/vulkan.rs
+++ b/mm-client/src/vulkan.rs
@@ -988,6 +988,28 @@ pub fn create_ycbcr_sampler_conversion(
     Ok(conversion)
 }
 
+pub fn get_ycbcr_conversion_properties(
+    device: vk::PhysicalDevice,
+    instance: &ash::Instance,
+    format: vk::Format
+) -> anyhow::Result<vk::SamplerYcbcrConversionImageFormatProperties> {
+    let mut ycbcr_props = vk::SamplerYcbcrConversionImageFormatProperties::builder().build();
+    let mut image_format_props2 = vk::ImageFormatProperties2::builder()
+        .push_next(&mut ycbcr_props);
+    
+    let image_format_info = vk::PhysicalDeviceImageFormatInfo2::builder()
+        .format(format)
+        .ty(vk::ImageType::TYPE_2D)
+        .tiling(vk::ImageTiling::OPTIMAL)
+        .usage(vk::ImageUsageFlags::SAMPLED);
+    
+    unsafe { 
+        instance.get_physical_device_image_format_properties2(device, &image_format_info, &mut image_format_props2)?; 
+    }
+    
+    Ok(ycbcr_props)
+}
+
 unsafe extern "system" fn vulkan_debug_utils_callback(
     message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
     message_type: vk::DebugUtilsMessageTypeFlagsEXT,


### PR DESCRIPTION
Hello! First off, I wanted to thank you for writing this application.  It's exactly the thing I was looking for after running into insurmountable issues with Steam Remote Play and Sunshine/Moonlight, and I appreciate the straightforward code organization.

As for the reason I'm opening this pull request - I was running into an error when attempting to launch mmclient.  The specific error was ERROR_OUT_OF_POOL_MEMORY, and a rust backtrace took me to the call to `allocate_descriptor_sets` within `render.rs`.  I did a little digging, and at first everything looked correct - there should have been room for `swapchain_images.len()` descriptors, but mine was failing at allocation 2 of 5.  I did a little more digging, and I learned that different Vulkan devices can use a different number of descriptors for YCbCr conversion (my device was using 3 descriptors for each image).  The code I've added here pulls the number of descriptors needed for the device and ups the pool size to accomodate.