### PR TITLE
Steam deck client fixes

### DIFF
--- a/mm-client/src/audio.rs
+++ b/mm-client/src/audio.rs
@@ -358,7 +358,12 @@ fn select_conf(
         let buffer_size = match conf_range.buffer_size() {
             cpal::SupportedBufferSize::Unknown => cpal::BufferSize::Default,
             cpal::SupportedBufferSize::Range { min, .. } => {
-                cpal::BufferSize::Fixed(std::cmp::max(*min, sample_rate / 100))
+                let size = std::cmp::max(*min, sample_rate / 100);
+                let mut buffer_size = 2;
+                while buffer_size < size {
+                    buffer_size *= 2;
+                }
+                cpal::BufferSize::Fixed(buffer_size)
             }
         };
 

--- a/mm-client/src/bin/mmclient.rs
+++ b/mm-client/src/bin/mmclient.rs
@@ -568,13 +568,17 @@ impl AttachmentWindow {
                     }
                 }
                 LockPointer(x, y) => {
-                    debug!(x, y, "cursor locked");
+                    debug!(x, y, "Locking cursor.");
 
                     // On most platforms, we have to lock the cursor before we
                     // warp it. On mac, it's the other way around.
                     #[cfg(not(target_vendor = "apple"))]
                     self.window
-                        .set_cursor_grab(winit::window::CursorGrabMode::Locked)?;
+                        .set_cursor_grab(winit::window::CursorGrabMode::Locked)
+                        .or_else(|_| { 
+                            debug!("Could not lock cursor. Falling back to confining cursor.");
+                            self.window.set_cursor_grab(winit::window::CursorGrabMode::Confined)
+                        })?;
 
                     if let Some(aspect) = self.renderer.get_texture_aspect() {
                         let width = self.attachment_config.width;
@@ -595,7 +599,7 @@ impl AttachmentWindow {
                         let pos: winit::dpi::PhysicalPosition<f64> = (x, y).into();
                         self.window.set_cursor_position(pos)?;
                     }
-
+                    
                     #[cfg(target_vendor = "apple")]
                     self.window
                         .set_cursor_grab(winit::window::CursorGrabMode::Locked)?;


### PR DESCRIPTION
Hello again!  While tinkering, I was able to fix a couple of issues I saw and thought it might be helpful to push these adjustments upstream.  For reference, I'm working on getting mmclient set up and running on my Steam Deck OLED.

My first commit (fixing cursor lock) stops an issue I was seeing where the client would frequently crash.  Winit wasn't able to lock the cursor on this device, and so any application that tried to do so would cause the client to abort. I feel like this fix is safe - it won't affect anything that was already working, and confining the cursor seemed to work just as well from my test cases.

My second commit (changing the audio buffer size) is a little more invasive, and I'm honestly not 100% sure why it fixed the issue I was seeing.  The issue it fixes is this: on my Steam Deck, when running an application, audio was delayed by about 1-2 seconds and was extremely static-y/poppy sounding (video and input seemed to be just fine, only audio had the problem).  Research led me to believe this could be caused by audio buffer size, so that's where I started investigating.  The sample_rate coming in was 48000, and so the buffer size was being set to 480 (which seems reasonable).  On a whim, I tried hardcoding the value to 512, and, like magic, the problem went away.  I looked around and found a mention of powers of 2 being better for some Linux audio functions, but nothing concrete (this seems to be specific to JACK - https://wiki.linuxaudio.org/wiki/list_of_jack_frame_period_settings_ideal_for_usb_interface).  Testing this change on other clients didn't seem to introduce any issues (audio still worked fine), so I figured I'd roll with it.

Feel free to take one or both (or none) of these changes - just figured I would put them up here to try and help anyone else who might face similar issues.