### PR TITLE
Fixing gilrs LeftZ mapping

### DIFF
--- a/mm-client/src/gamepad.rs
+++ b/mm-client/src/gamepad.rs
@@ -297,7 +297,7 @@ fn girls_axis_to_proto(axis: gilrs::Axis) -> Option<GamepadAxis> {
         gilrs::Axis::LeftStickY => GamepadAxis::LeftY,
         gilrs::Axis::RightStickX => GamepadAxis::RightX,
         gilrs::Axis::RightStickY => GamepadAxis::RightY,
-        gilrs::Axis::LeftZ => GamepadAxis::RightTrigger,
+        gilrs::Axis::LeftZ => GamepadAxis::LeftTrigger,
         gilrs::Axis::RightZ => GamepadAxis::RightTrigger,
         _ => return None,
     };


### PR DESCRIPTION
Minor change here.  I found this mismatch when digging through the input code researching something else (my West/North input seem to be swapped in all games for some reason? But that's a different discussion).