### PR TITLE
Add better mmclient build docs

### DIFF
--- a/docs/content/setup/client.md
+++ b/docs/content/setup/client.md
@@ -35,7 +35,7 @@ alsa (linux only)
 ffmpeg 6.x
 ```
 
-Besides Rust itself, the following command will install everything on ubuntu:
+Besides Rust itself, the following command will install everything on Ubuntu:
 
 ```
 apt install \
@@ -47,4 +47,21 @@ Or using homebrew on macOS:
 
 ```
 brew install nasm cmake ffmpeg@6 protobuf
+```
+
+Note that `mmclient` doesn't compile with the latest versions of clang. It's tested against clang 18 (which is part of the Ubuntu 24.04 repositories). If you have multiple clang versions installed and version 18 is among them, you'll probably want to set some environment variables to point to the clang 18 library paths as described in the [clang-sys docs](https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#environment-variables).
+
+For building `mmclient` you'll also need to have [slang v2025.5](https://github.com/shader-slang/slang/releases/tag/v2025.5) available. Since this isn't packaged on most distributions, you'll likely need to install the release assets yourself and specify the following environment variables at build time:
+
+```bash
+# Create temporary directory to download slang into.
+mkdir -p /tmp/slang
+# Download linux release asset for slang v2025.5 into temporary directory.
+curl -o /tmp/slang/slang.tar.gz https://github.com/shader-slang/slang/releases/download/v2025.5/slang-2025.5-linux-x86_64.tar.gz
+# Extract assets from archive.
+tar -xf /tmp/slang/slang.tar.gz
+# Set required environment variables for building `mmclient`.
+export SLANG_DIR=/tmp/slang
+export DYLD_LIBRARY_PATH=/tmp/slang/lib
+export LD_LIBRARY_PATH=/tmp/slang/lib
 ```


### PR DESCRIPTION
Hi,

This pull request adds some additional documentation on how to build the `mmclient` crate.
Since slang is almost never packaged, I think it would be nice to have the steps documented on how to build it with the downloaded slang release asset (and also which asset to use).
Also, because we use an old version of `slang-sys` which doesn't build with the latest versions of clang, it would also be nice to have some documentation that you'll probably need clang 18 for building the client.

